### PR TITLE
fix: イベント確定後の場所をクリックで詳細オーバーレイを表示する

### DIFF
--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -886,12 +886,45 @@ export default function EventDetailPage() {
               <p className="text-xs uppercase tracking-[0.2em] text-[var(--muted)]">
                 場所
               </p>
-              <p className="mt-2 text-sm font-semibold">
-                {event.fixedPlaceName ?? "候補から決定"}
-              </p>
-              <p className="text-xs text-[var(--muted)]">
-                {event.fixedPlaceAddress ?? ""}
-              </p>
+              {event.fixedPlaceName ? (
+                <button
+                  onClick={() => {
+                    const matched = event.placeCandidates.find(
+                      (c) => c.placeId === event.fixedPlaceId
+                    );
+                    setSelectedPlaceDetail(
+                      matched ?? {
+                        id: event.fixedPlaceId ?? "",
+                        placeId: event.fixedPlaceId ?? "",
+                        name: event.fixedPlaceName ?? "",
+                        address: event.fixedPlaceAddress ?? "",
+                        lat: 0,
+                        lng: 0,
+                        photoUrl: null,
+                        mapsUrl: event.fixedPlaceAddress
+                          ? `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(event.fixedPlaceAddress)}`
+                          : undefined,
+                        score: 0,
+                        source: "system",
+                        myScore: null,
+                      }
+                    );
+                  }}
+                  className="mt-2 text-left"
+                >
+                  <p className="text-sm font-semibold underline-offset-2 hover:underline">
+                    {event.fixedPlaceName}
+                  </p>
+                  <p className="text-xs text-[var(--muted)]">
+                    {event.fixedPlaceAddress ?? ""}
+                  </p>
+                </button>
+              ) : (
+                <>
+                  <p className="mt-2 text-sm font-semibold">候補から決定</p>
+                  <p className="text-xs text-[var(--muted)]"></p>
+                </>
+              )}
             </div>
             <div className="p-1">
               <p className="text-xs uppercase tracking-[0.2em] text-[var(--muted)]">

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -882,7 +882,7 @@ export default function EventDetailPage() {
               </p>
               <p className="mt-2 text-sm font-semibold">{event.area ?? "未設定"}</p>
             </div>
-            <div className="p-1">
+            <div className="min-w-0 p-1">
               <p className="text-xs uppercase tracking-[0.2em] text-[var(--muted)]">
                 場所
               </p>
@@ -910,14 +910,16 @@ export default function EventDetailPage() {
                       }
                     );
                   }}
-                  className="mt-2 text-left"
+                  className="mt-2 w-full overflow-hidden text-left"
                 >
-                  <p className="text-sm font-semibold underline-offset-2 hover:underline">
-                    {event.fixedPlaceName}
-                  </p>
-                  <p className="text-xs text-[var(--muted)]">
-                    {event.fixedPlaceAddress ?? ""}
-                  </p>
+                  <div className="mt-2 flex items-center gap-1">
+                    <span className="material-symbols-rounded text-base text-[var(--accent)] shrink-0">location_on</span>
+                    <div className="min-w-0 flex-1">
+                      <p className="text-sm font-semibold text-[var(--accent)]">{event.fixedPlaceName}</p>
+                      <p className="text-xs text-[var(--muted)] truncate">{event.fixedPlaceAddress ?? ""}</p>
+                    </div>
+                    <span className="material-symbols-rounded text-sm text-[var(--muted)] shrink-0">open_in_new</span>
+                  </div>
                 </button>
               ) : (
                 <>

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -901,9 +901,13 @@ export default function EventDetailPage() {
                         lat: 0,
                         lng: 0,
                         photoUrl: null,
-                        mapsUrl: event.fixedPlaceAddress
-                          ? `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(event.fixedPlaceAddress)}`
-                          : undefined,
+                        mapsUrl: (() => {
+                          const query = event.fixedPlaceAddress ?? event.fixedPlaceName ?? "";
+                          const base = `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(query)}`;
+                          return event.fixedPlaceId
+                            ? `${base}&query_place_id=${encodeURIComponent(event.fixedPlaceId)}`
+                            : query ? base : undefined;
+                        })(),
                         score: 0,
                         source: "system",
                         myScore: null,


### PR DESCRIPTION
## 概要
イベント確定後の「場所」セクションにて、店名をクリックすると詳細オーバーレイが開く機能（#55）に加え、クリッカブルであることが直感的に伝わるUIを実装。合わせてフォールバック時の `mapsUrl` 生成ロジックのバグを修正。

**関連ドキュメント**
- Issue #55: イベント確定後の場所をクリックで詳細オーバーレイを表示する

## 影響範囲
- 本番環境の利用者への影響: UI変更のみ（DB変更・マイグレーションなし）
- 影響ファイル: `app/events/[id]/page.tsx` のみ
- 対象: confirmed / completed 状態のイベント詳細ページの「場所」セクション

## 変更点

**AS IS**
- 店名が静的テキストのみで表示され、クリックできるとわからない（ホバー時のみ underline）
- 住所テキストが長い場合に枠外にはみ出す
- `fixedPlaceAddress` が null のとき `mapsUrl` が `undefined` になり、モーダルの lat/lng=0,0 フォールバック（大西洋上）でマップが開く
- フォールバック生成の `mapsUrl` に `query_place_id` が付与されておらず、既存 API の挙動と不一致

**TO BE**
- `location_on` アイコン（アクセントカラー）＋店名（アクセントカラー）でタップ可能であることを常時明示
- 住所を1行に収め、右端で `...` 省略（`truncate`）
- `open_in_new` アイコンを右端に配置してオーバーレイが開くことを示唆
- `min-w-0` + `w-full overflow-hidden` でグリッド内のフレームアウトを修正
- `fixedPlaceAddress` が null でも `fixedPlaceName` をクエリに使い `mapsUrl` を必ず生成
- `fixedPlaceId` がある場合は `query_place_id` を付与し既存 API と挙動を統一

## QA 観点
- `fixedPlaceName` が null のとき「候補から決定」テキストが表示され、ボタンが出ないこと
- `fixedPlaceAddress` が null のとき、`fixedPlaceName` をクエリとした mapsUrl が生成されること
- `fixedPlaceId` がある場合、mapsUrl に `query_place_id` パラメータが含まれること
- 住所が長い場合に `truncate` で省略され、グリッドからはみ出さないこと
- モバイル（縦1列）・PC（4列グリッド）どちらでもレイアウトが崩れないこと

## 動作確認ケース
- confirmed 状態のイベント詳細ページで「場所」の店舗名をクリック → 詳細モーダルが開く
- モーダルの「Googleマップで開く」ボタンをタップ → 正しい場所でマップが開く
- open 状態の場所候補クリック（既存動作）が壊れていない
- 住所が長い文字列でも1行で省略表示され、右端の `open_in_new` アイコンが枠内に収まる

## レビュアーに特に見て欲しいポイント
- `mapsUrl` 生成の即時実行関数（IIFE）で `fixedPlaceId` 有無・`fixedPlaceAddress` 有無の3ケースを網羅している点
- グリッドセルに `min-w-0` を追加してフレームアウトを防止している点（Tailwind の grid + flex 組み合わせ時の典型的な問題への対処）

closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)