### PR TITLE
Add invite sharing flow

### DIFF
--- a/app/api/events/[id]/invites/route.ts
+++ b/app/api/events/[id]/invites/route.ts
@@ -50,8 +50,20 @@ export async function POST(
       { status: 403 }
     );
   }
+  // If creating a shareable invite link, create a token record and return it.
+  if (body.mode === "link") {
+    const created = await prisma.eventInvite.create({
+      data: {
+        eventId: event.id,
+        inviterId: body.actorId as string,
+        inviteeId: null,
+        token: crypto.randomUUID(),
+        status: "pending",
+      },
+    });
 
-
+    return NextResponse.json({ token: created.token });
+  }
 
   if (!body.friendIds || body.friendIds.length === 0) {
     return NextResponse.json(

--- a/app/api/events/[id]/join/route.ts
+++ b/app/api/events/[id]/join/route.ts
@@ -116,7 +116,7 @@ export async function POST(
       const tokenInvite = await prisma.eventInvite.findUnique({
         where: { token: body.inviteToken },
       });
-      if (tokenInvite) {
+      if (tokenInvite && tokenInvite.eventId === id && tokenInvite.inviterId !== body.userId) {
         inviterIdFromToken = tokenInvite.inviterId;
         // Update the invite to mark this user as invitee if not already set
         if (!tokenInvite.inviteeId) {

--- a/app/api/events/[id]/join/route.ts
+++ b/app/api/events/[id]/join/route.ts
@@ -49,7 +49,7 @@ export async function POST(
   { params }: { params: Promise<{ id: string }> }
 ) {
   const { id } = await params;
-  const body = (await request.json()) as { userId?: string };
+  const body = (await request.json()) as { userId?: string; inviteToken?: string };
 
   if (!body.userId) {
     return NextResponse.json({ message: "Missing userId" }, { status: 400 });
@@ -109,6 +109,28 @@ export async function POST(
     });
   }
 
+  // If user accessed via invite link (inviteToken), process the invite and create friendship
+  let inviterIdFromToken: string | null = null;
+  if (body.inviteToken) {
+    try {
+      const tokenInvite = await prisma.eventInvite.findUnique({
+        where: { token: body.inviteToken },
+      });
+      if (tokenInvite) {
+        inviterIdFromToken = tokenInvite.inviterId;
+        // Update the invite to mark this user as invitee if not already set
+        if (!tokenInvite.inviteeId) {
+          await prisma.eventInvite.update({
+            where: { id: tokenInvite.id },
+            data: { inviteeId: body.userId, status: "accepted" },
+          });
+        }
+      }
+    } catch {
+      // Ignore invite token processing failures
+    }
+  }
+
   const participant = await prisma.eventParticipant.upsert({
     where: { eventId_userId: { eventId: id, userId: body.userId } },
     update: { status: nextStatus },
@@ -143,6 +165,21 @@ export async function POST(
 
   if (participant.status === "approved") {
     await syncApprovedEventFriendships(id);
+  }
+
+  // Create friendship with inviter if invite link was used
+  if (inviterIdFromToken) {
+    try {
+      await prisma.friendship.createMany({
+        data: [
+          { userId: body.userId, friendId: inviterIdFromToken, status: "pending" },
+          { userId: inviterIdFromToken, friendId: body.userId, status: "pending" },
+        ],
+        skipDuplicates: true,
+      });
+    } catch {
+      // Ignore friendship creation failures to not block event join
+    }
   }
 
   return NextResponse.json({ status: participant.status });

--- a/app/api/profiles/route.ts
+++ b/app/api/profiles/route.ts
@@ -18,6 +18,7 @@ export async function POST(request: Request) {
     favoriteAreas?: string[];
     favoritePlaces?: string[];
     availability?: unknown;
+    inviteToken?: string | null;
   };
 
   if (!body.userId || !body.displayName) {
@@ -77,6 +78,28 @@ export async function POST(request: Request) {
       message:
         "プロフィールを登録すると、イベント作成やマッチングがスムーズになります。プロフィール設定を完了しましょう。",
     });
+    // If user was created via an invite link, attach invite and create pending friendship
+    if (body.inviteToken) {
+      try {
+        const invite = await prisma.eventInvite.findUnique({ where: { token: body.inviteToken } });
+        if (invite && !invite.inviteeId) {
+          await prisma.eventInvite.update({
+            where: { id: invite.id },
+            data: { inviteeId: body.userId, status: "accepted" },
+          });
+
+          await prisma.friendship.createMany({
+            data: [
+              { userId: body.userId, friendId: invite.inviterId, status: "pending" },
+              { userId: invite.inviterId, friendId: body.userId, status: "pending" },
+            ],
+            skipDuplicates: true,
+          });
+        }
+      } catch {
+        // Ignore invite processing failures to avoid blocking profile creation
+      }
+    }
   }
 
   return NextResponse.json(profile);

--- a/app/auth/callback/page.tsx
+++ b/app/auth/callback/page.tsx
@@ -225,6 +225,14 @@ export default function AuthCallbackPage() {
       if (response.ok) {
         profile = (await response.json()) as ProfileResponse;
       } else {
+        const pendingInviteToken = (() => {
+          try {
+            return window.sessionStorage.getItem("pendingInviteToken");
+          } catch {
+            return null;
+          }
+        })();
+
         await fetch("/api/profiles", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -234,6 +242,7 @@ export default function AuthCallbackPage() {
             avatarIcon: lineDefaults.avatarIcon,
             birthDate: lineDefaults.birthDate,
             lineUserId,
+            inviteToken: pendingInviteToken ?? undefined,
           }),
         });
 
@@ -279,6 +288,12 @@ export default function AuthCallbackPage() {
 
       const redirectPath = eventReturnTo ?? "/profile/setup";
       markRecentAuth();
+      try {
+        window.sessionStorage.removeItem("pendingInviteToken");
+        window.sessionStorage.removeItem("pendingInviteRef");
+      } catch {
+        // ignore
+      }
       router.replace(redirectPath);
     };
 

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -820,7 +820,7 @@ export default function EventDetailPage() {
       inviteLink ??
       createdInviteLink ??
       `${window.location.origin}/events/${eventId}${userId ? `?ref=${encodeURIComponent(userId)}` : ""}`;
-    const text = `このイベントに一緒に参加しませんか？ ${event.purpose} ${urlToShare}`;
+    const text = `このイベントに一緒に参加しませんか？ ${urlToShare}`;
 
     try {
       if ((navigator as any).share) {
@@ -828,7 +828,7 @@ export default function EventDetailPage() {
         setInviteMessage("共有しました。");
         return;
       }
-    } catch (error) {
+    } catch {
       // navigator.share failed, show fallback UI
     }
 
@@ -884,17 +884,6 @@ export default function EventDetailPage() {
       setCalendarMessage("カレンダーの登録に失敗しました。時間をおいて再度お試しください。");
     } finally {
       setIsCalendarDownloading(false);
-    }
-  };
-
-  const handleCopyInviteLink = async () => {
-    if (!inviteLink) return;
-
-    try {
-      await navigator.clipboard.writeText(inviteLink);
-      setInviteMessage("招待リンクをコピーしました。");
-    } catch {
-      setInviteMessage("コピーに失敗しました。リンクを長押しして共有してください。");
     }
   };
 
@@ -1510,39 +1499,6 @@ export default function EventDetailPage() {
                 : "選択したフレンドにイベント招待を送信します。"}
             </p>
 
-            <div className="mt-3 rounded-2xl bg-white p-3 shadow-sm">
-              <div className="flex items-center justify-between gap-2">
-                <p className="text-xs font-semibold text-[var(--foreground)]">リンクで招待</p>
-                <button
-                  onClick={handleCreateInviteLink}
-                  disabled={
-                    event.visibility === "private" && userId !== event.owner.userId
-                  }
-                  className="flex items-center gap-1 rounded-full bg-orange-100 px-3 py-1 text-xs font-semibold text-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-60"
-                >
-                  <span className="material-symbols-rounded text-sm">link</span>
-                  作成する
-                </button>
-              </div>
-              {inviteLink && (
-                <div className="mt-2 flex items-center gap-2">
-                  <p className="min-w-0 flex-1 truncate text-xs text-[var(--muted)]">{inviteLink}</p>
-                  <button
-                    onClick={handleCopyInviteLink}
-                    className="grid h-8 w-8 place-items-center rounded-full bg-orange-100 text-[var(--accent)]"
-                    aria-label="招待リンクをコピー"
-                  >
-                    <span className="material-symbols-rounded text-sm">content_copy</span>
-                  </button>
-                </div>
-              )}
-              {event.visibility === "private" && userId !== event.owner.userId && (
-                <p className="mt-2 text-[11px] text-[var(--muted)]">
-                  プライベートイベントのリンク招待はオーナーのみ作成できます。
-                </p>
-              )}
-            </div>
-
             {inviteMessage && <p className="mt-3 text-xs text-[var(--accent)]">{inviteMessage}</p>}
 
             {friends.length === 0 ? (
@@ -1636,7 +1592,7 @@ export default function EventDetailPage() {
                 <button
                   onClick={() => {
                     const url = inviteLink ?? `${window.location.origin}/events/${eventId}?ref=${userId ?? ""}`;
-                    const text = `このイベントに一緒に参加しませんか？ ${event.purpose} ${url}`;
+                    const text = `このイベントに一緒に参加しませんか？ ${url}`;
                     window.open(`https://line.me/R/msg/text/?${encodeURIComponent(text)}`);
                     console.log("[DEBUG] LINE share clicked, url:", url);
                   }}
@@ -1648,7 +1604,7 @@ export default function EventDetailPage() {
                 <button
                   onClick={() => {
                     const url = inviteLink ?? `${window.location.origin}/events/${eventId}?ref=${userId ?? ""}`;
-                    const text = `このイベントに一緒に参加しませんか？ ${event.purpose}`;
+                    const text = `このイベントに一緒に参加しませんか？`;
                     window.open(`https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(url)}`);
                     console.log("[DEBUG] X (Twitter) share clicked, url:", url);
                   }}

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -770,15 +770,15 @@ export default function EventDetailPage() {
     setShowInviteOverlay(false);
   };
 
-  const handleCreateInviteLink = async () => {
+  const handleCreateInviteLink = async (quiet = false) => {
     if (!event || !userId) return null;
 
     if (event.visibility === "private" && userId !== event.owner.userId) {
-      setInviteMessage("プライベートイベントではオーナーのみ招待リンクを作成できます。");
+      if (!quiet) setInviteMessage("プライベートイベントではオーナーのみ招待リンクを作成できます。");
       return null;
     }
 
-    setInviteMessage(null);
+    if (!quiet) setInviteMessage(null);
     try {
       const response = await fetch(`/api/events/${eventId}/invites`, {
         method: "POST",
@@ -787,14 +787,14 @@ export default function EventDetailPage() {
       });
 
       if (!response.ok) {
-        setInviteMessage("招待リンクの作成に失敗しました。");
+        if (!quiet) setInviteMessage("招待リンクの作成に失敗しました。");
         return null;
       }
 
       const data = await response.json();
       const token = data.token as string | undefined;
       if (!token) {
-        setInviteMessage("招待リンクの作成に失敗しました。");
+        if (!quiet) setInviteMessage("招待リンクの作成に失敗しました。");
         return null;
       }
 
@@ -802,10 +802,10 @@ export default function EventDetailPage() {
         token
       )}&ref=${encodeURIComponent(userId)}`;
       setInviteLink(url);
-      setInviteMessage("招待リンクを作成しました。");
+      if (!quiet) setInviteMessage("招待リンクを作成しました。");
       return url;
     } catch {
-      setInviteMessage("招待リンクの作成に失敗しました。");
+      if (!quiet) setInviteMessage("招待リンクの作成に失敗しました。");
       return null;
     }
   };
@@ -814,26 +814,25 @@ export default function EventDetailPage() {
     if (!event) return;
 
     // Ensure we have an invite link (server-backed token) so tracking works.
-    const createdInviteLink = !inviteLink && userId ? await handleCreateInviteLink() : null;
+    const createdInviteLink = !inviteLink && userId ? await handleCreateInviteLink(true) : null;
     const urlToShare =
       inviteLink ??
       createdInviteLink ??
       `${window.location.origin}/events/${eventId}${userId ? `?ref=${encodeURIComponent(userId)}` : ""}`;
-    const text = `このイベントに一緒に参加しませんか？ ${urlToShare}`;
+    const text = "このイベントに一緒に参加しませんか？";
 
-    try {
-      if ((navigator as any).share) {
+    if ((navigator as any).share) {
+      try {
         await (navigator as any).share({ title: event.purpose, text, url: urlToShare });
-        setInviteMessage("共有しました。");
-        return;
+      } catch (error) {
+        console.log("[DEBUG] navigator.share failed or cancelled:", error);
       }
-    } catch (error) {
-      console.log("[DEBUG] navigator.share failed or cancelled:", error);
+      return;
     }
 
     // Fallback: Copy link to clipboard
     try {
-      await navigator.clipboard.writeText(urlToShare);
+      await navigator.clipboard.writeText(`${text} ${urlToShare}`);
       setInviteMessage("招待リンクをコピーしました。");
     } catch (error) {
       console.log("[DEBUG] Copy failed:", error);
@@ -1491,7 +1490,10 @@ export default function EventDetailPage() {
             <div className="flex items-center justify-between">
               <h3 className="text-base font-semibold">フレンドを選択</h3>
               <button
-                onClick={() => setShowInviteOverlay(false)}
+                onClick={() => {
+                  setShowInviteOverlay(false);
+                  setInviteMessage(null);
+                }}
                 className="grid h-8 w-8 place-items-center rounded-full bg-white text-[var(--muted)]"
                 aria-label="閉じる"
               >

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -191,6 +191,7 @@ export default function EventDetailPage() {
     "same_members_new_place" | "same_place_new_members" | null
   >(null);
   const [inviteLink, setInviteLink] = useState<string | null>(null);
+  const [showShareFallback, setShowShareFallback] = useState(false);
 
   const [placeQuery, setPlaceQuery] = useState("");
   const [placeResults, setPlaceResults] = useState<PlaceResult[]>([]);
@@ -236,6 +237,22 @@ export default function EventDetailPage() {
       active = false;
       subscription.unsubscribe();
     };
+  }, []);
+
+  useEffect(() => {
+    try {
+      const searchParams = new URL(window.location.href).searchParams;
+      const ref = searchParams.get("ref");
+      const inviteToken = searchParams.get("inviteToken");
+      if (ref) {
+        window.sessionStorage.setItem("pendingInviteRef", ref);
+      }
+      if (inviteToken) {
+        window.sessionStorage.setItem("pendingInviteToken", inviteToken);
+      }
+    } catch {
+      // ignore
+    }
   }, []);
 
   useEffect(() => {
@@ -465,10 +482,20 @@ export default function EventDetailPage() {
       setIsAuthOverlayOpen(true);
       return;
     }
+    
+    // Get inviteToken from sessionStorage if user accessed via invite link
+    const inviteToken = (() => {
+      try {
+        return window.sessionStorage.getItem("pendingInviteToken");
+      } catch {
+        return undefined;
+      }
+    })();
+    
     await fetch(`/api/events/${eventId}/join`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ userId }),
+      body: JSON.stringify({ userId, inviteToken }),
     });
     const query = userId ? `?viewerId=${userId}` : "";
     const response = await fetch(`/api/events/${eventId}${query}`, { cache: "no-store" });
@@ -745,15 +772,67 @@ export default function EventDetailPage() {
   };
 
   const handleCreateInviteLink = async () => {
-    if (!event || !userId) return;
+    if (!event || !userId) return null;
 
     if (event.visibility === "private" && userId !== event.owner.userId) {
       setInviteMessage("プライベートイベントではオーナーのみ招待リンクを作成できます。");
-      return;
+      return null;
     }
 
-    setInviteLink(`${window.location.origin}/events/${eventId}`);
-    setInviteMessage("招待リンクを作成しました。");
+    setInviteMessage(null);
+    try {
+      const response = await fetch(`/api/events/${eventId}/invites`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ actorId: userId, mode: "link" }),
+      });
+
+      if (!response.ok) {
+        setInviteMessage("招待リンクの作成に失敗しました。");
+        return null;
+      }
+
+      const data = await response.json();
+      const token = data.token as string | undefined;
+      if (!token) {
+        setInviteMessage("招待リンクの作成に失敗しました。");
+        return null;
+      }
+
+      const url = `${window.location.origin}/events/${eventId}?inviteToken=${encodeURIComponent(
+        token
+      )}&ref=${encodeURIComponent(userId)}`;
+      setInviteLink(url);
+      setInviteMessage("招待リンクを作成しました。");
+      return url;
+    } catch {
+      setInviteMessage("招待リンクの作成に失敗しました。");
+      return null;
+    }
+  };
+
+  const handleShare = async () => {
+    if (!event) return;
+
+    // Ensure we have an invite link (server-backed token) so tracking works.
+    const createdInviteLink = !inviteLink && userId ? await handleCreateInviteLink() : null;
+    const urlToShare =
+      inviteLink ??
+      createdInviteLink ??
+      `${window.location.origin}/events/${eventId}${userId ? `?ref=${encodeURIComponent(userId)}` : ""}`;
+    const text = `このイベントに一緒に参加しませんか？ ${event.purpose} ${urlToShare}`;
+
+    try {
+      if ((navigator as any).share) {
+        await (navigator as any).share({ title: event.purpose, text, url: urlToShare });
+        setInviteMessage("共有しました。");
+        return;
+      }
+    } catch (error) {
+      // navigator.share failed, show fallback UI
+    }
+
+    setShowShareFallback(true);
   };
 
   const handleCalendarDownload = async () => {
@@ -848,6 +927,15 @@ export default function EventDetailPage() {
               <span className="material-symbols-rounded">chevron_left</span>
             </Link>
             <h1 className="text-lg font-semibold">イベント詳細</h1>
+            <div className="ml-auto hidden">
+              <button
+                onClick={handleShare}
+                className="grid h-9 w-9 place-items-center rounded-full bg-white text-[var(--foreground)] shadow-sm"
+                aria-label="共有"
+              >
+                <span className="material-symbols-rounded">share</span>
+              </button>
+            </div>
           </div>
         </div>
       </header>
@@ -862,8 +950,20 @@ export default function EventDetailPage() {
                 {visibilityMeta[event.visibility].label}
               </p>
               <h1 className="text-3xl font-semibold">{event.purpose}</h1>
-              <div className="mt-3 text-sm text-[var(--muted)]">
-                <AvatarName displayName={event.owner.displayName} avatarIcon={event.owner.avatarIcon} />
+              <div className="mt-3 flex items-center justify-between gap-3">
+                <div className="text-sm text-[var(--muted)]">
+                  <AvatarName displayName={event.owner.displayName} avatarIcon={event.owner.avatarIcon} />
+                </div>
+                <div>
+                  <button
+                    onClick={handleShare}
+                    className="inline-flex items-center gap-2 rounded-full bg-white px-3 py-2 text-sm font-semibold text-[var(--foreground)] shadow-sm"
+                    aria-label="共有"
+                  >
+                    <span className="material-symbols-rounded">share</span>
+                    共有
+                  </button>
+                </div>
               </div>
           </div>
 
@@ -1512,6 +1612,71 @@ export default function EventDetailPage() {
                 ? "オーナーに申請する"
                 : "招待する"}
             </button>
+          </div>
+        </div>
+      )}
+
+      {showShareFallback && event && (
+        <div className="fixed inset-0 z-[60] flex items-end bg-black/35 p-3 sm:items-center sm:justify-center sm:p-6">
+          <div className="w-full max-w-md rounded-3xl bg-[var(--surface)] p-4 shadow-2xl">
+            <div className="flex items-center justify-between">
+              <h3 className="text-base font-semibold">共有</h3>
+              <button
+                onClick={() => setShowShareFallback(false)}
+                className="grid h-8 w-8 place-items-center rounded-full bg-white text-[var(--muted)]"
+                aria-label="閉じる"
+              >
+                <span className="material-symbols-rounded">close</span>
+              </button>
+            </div>
+
+            <div className="mt-4 flex flex-col gap-3">
+              <p className="text-sm text-[var(--muted)]">このイベントを共有する</p>
+              <div className="grid grid-cols-1 gap-2">
+                <button
+                  onClick={() => {
+                    const url = inviteLink ?? `${window.location.origin}/events/${eventId}?ref=${userId ?? ""}`;
+                    const text = `このイベントに一緒に参加しませんか？ ${event.purpose} ${url}`;
+                    window.open(`https://line.me/R/msg/text/?${encodeURIComponent(text)}`);
+                    console.log("[DEBUG] LINE share clicked, url:", url);
+                  }}
+                  className="flex items-center justify-center gap-2 rounded-full bg-green-500 hover:bg-green-600 px-4 py-3 text-sm font-semibold text-white shadow-sm transition-colors"
+                >
+                  <span className="material-symbols-rounded">chat</span>
+                  LINEで共有
+                </button>
+                <button
+                  onClick={() => {
+                    const url = inviteLink ?? `${window.location.origin}/events/${eventId}?ref=${userId ?? ""}`;
+                    const text = `このイベントに一緒に参加しませんか？ ${event.purpose}`;
+                    window.open(`https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(url)}`);
+                    console.log("[DEBUG] X (Twitter) share clicked, url:", url);
+                  }}
+                  className="flex items-center justify-center gap-2 rounded-full bg-black hover:bg-gray-800 px-4 py-3 text-sm font-semibold text-white shadow-sm transition-colors"
+                >
+                  <span className="material-symbols-rounded">share</span>
+                  Xで共有
+                </button>
+                <button
+                  onClick={() => {
+                    const url = inviteLink ?? `${window.location.origin}/events/${eventId}?ref=${userId ?? ""}`;
+                    try {
+                      navigator.clipboard.writeText(url);
+                      setInviteMessage("招待リンクをコピーしました。");
+                      console.log("[DEBUG] Link copied:", url);
+                    } catch (error) {
+                      console.log("[DEBUG] Copy failed:", error);
+                      setInviteMessage("コピーに失敗しました。リンクを長押しして共有してください。");
+                    }
+                    setShowShareFallback(false);
+                  }}
+                  className="flex items-center justify-center gap-2 rounded-full bg-white border-2 border-gray-300 hover:bg-gray-50 px-4 py-3 text-sm font-semibold text-[var(--foreground)] shadow-sm transition-colors"
+                >
+                  <span className="material-symbols-rounded">content_copy</span>
+                  リンクをコピー
+                </button>
+              </div>
+            </div>
           </div>
         </div>
       )}

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -825,6 +825,10 @@ export default function EventDetailPage() {
       try {
         await (navigator as any).share({ title: event.purpose, text, url: urlToShare });
       } catch (error) {
+        const err = error as any;
+        if (err && err.name === "AbortError") {
+          return;
+        }
         if (!quiet) setInviteMessage("共有に失敗しました。");
       }
       return;

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -810,7 +810,7 @@ export default function EventDetailPage() {
     }
   };
 
-  const handleShare = async () => {
+  const handleShare = async (quiet = false) => {
     if (!event) return;
 
     // Ensure we have an invite link (server-backed token) so tracking works.
@@ -825,7 +825,7 @@ export default function EventDetailPage() {
       try {
         await (navigator as any).share({ title: event.purpose, text, url: urlToShare });
       } catch (error) {
-        console.log("[DEBUG] navigator.share failed or cancelled:", error);
+        if (!quiet) setInviteMessage("共有に失敗しました。");
       }
       return;
     }
@@ -833,10 +833,9 @@ export default function EventDetailPage() {
     // Fallback: Copy link to clipboard
     try {
       await navigator.clipboard.writeText(`${text} ${urlToShare}`);
-      setInviteMessage("招待リンクをコピーしました。");
+      if (!quiet) setInviteMessage("招待リンクをコピーしました。");
     } catch (error) {
-      console.log("[DEBUG] Copy failed:", error);
-      setInviteMessage("コピーに失敗しました。リンクを長押しして共有してください。");
+      if (!quiet) setInviteMessage("コピーに失敗しました。リンクを長押しして共有してください。");
     }
   };
 
@@ -923,7 +922,7 @@ export default function EventDetailPage() {
             <h1 className="text-lg font-semibold">イベント詳細</h1>
             <div className="ml-auto hidden">
               <button
-                onClick={openInviteOverlay}
+                onClick={() => handleShare()}
                 className="grid h-9 w-9 place-items-center rounded-full bg-white text-[var(--foreground)] shadow-sm"
                 aria-label="共有"
               >
@@ -950,7 +949,7 @@ export default function EventDetailPage() {
                 </div>
                 <div>
                   <button
-                    onClick={openInviteOverlay}
+                    onClick={() => handleShare()}
                     className="inline-flex items-center gap-2 rounded-full bg-white px-3 py-2 text-sm font-semibold text-[var(--foreground)] shadow-sm"
                     aria-label="共有"
                   >
@@ -1579,7 +1578,7 @@ export default function EventDetailPage() {
               </button>
 
               <button
-                onClick={handleShare}
+                onClick={() => handleShare()}
                 disabled={!canAccessParticipantActions}
                 className="flex w-full items-center justify-center gap-2 rounded-full bg-white border-2 border-gray-200 hover:bg-gray-50 px-4 py-2 text-sm font-semibold text-[var(--foreground)] disabled:cursor-not-allowed disabled:opacity-50 transition-colors"
               >

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -191,7 +191,6 @@ export default function EventDetailPage() {
     "same_members_new_place" | "same_place_new_members" | null
   >(null);
   const [inviteLink, setInviteLink] = useState<string | null>(null);
-  const [showShareFallback, setShowShareFallback] = useState(false);
 
   const [placeQuery, setPlaceQuery] = useState("");
   const [placeResults, setPlaceResults] = useState<PlaceResult[]>([]);
@@ -828,11 +827,18 @@ export default function EventDetailPage() {
         setInviteMessage("共有しました。");
         return;
       }
-    } catch {
-      // navigator.share failed, show fallback UI
+    } catch (error) {
+      console.log("[DEBUG] navigator.share failed or cancelled:", error);
     }
 
-    setShowShareFallback(true);
+    // Fallback: Copy link to clipboard
+    try {
+      await navigator.clipboard.writeText(urlToShare);
+      setInviteMessage("招待リンクをコピーしました。");
+    } catch (error) {
+      console.log("[DEBUG] Copy failed:", error);
+      setInviteMessage("コピーに失敗しました。リンクを長押しして共有してください。");
+    }
   };
 
   const handleCalendarDownload = async () => {
@@ -918,7 +924,7 @@ export default function EventDetailPage() {
             <h1 className="text-lg font-semibold">イベント詳細</h1>
             <div className="ml-auto hidden">
               <button
-                onClick={handleShare}
+                onClick={openInviteOverlay}
                 className="grid h-9 w-9 place-items-center rounded-full bg-white text-[var(--foreground)] shadow-sm"
                 aria-label="共有"
               >
@@ -945,7 +951,7 @@ export default function EventDetailPage() {
                 </div>
                 <div>
                   <button
-                    onClick={handleShare}
+                    onClick={openInviteOverlay}
                     className="inline-flex items-center gap-2 rounded-full bg-white px-3 py-2 text-sm font-semibold text-[var(--foreground)] shadow-sm"
                     aria-label="共有"
                   >
@@ -1558,80 +1564,26 @@ export default function EventDetailPage() {
               </div>
             )}
 
-            <button
-              onClick={handleInviteFriends}
-              disabled={selectedInviteeIds.length === 0 || !canAccessParticipantActions}
-              className="mt-4 flex w-full items-center justify-center gap-2 rounded-full bg-[var(--accent)] px-4 py-2 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              <span className="material-symbols-rounded">send</span>
-              {event.visibility === "private" && userId !== event.owner.userId
-                ? "オーナーに申請する"
-                : "招待する"}
-            </button>
-          </div>
-        </div>
-      )}
-
-      {showShareFallback && event && (
-        <div className="fixed inset-0 z-[60] flex items-end bg-black/35 p-3 sm:items-center sm:justify-center sm:p-6">
-          <div className="w-full max-w-md rounded-3xl bg-[var(--surface)] p-4 shadow-2xl">
-            <div className="flex items-center justify-between">
-              <h3 className="text-base font-semibold">共有</h3>
+            <div className="mt-4 flex flex-col gap-2">
               <button
-                onClick={() => setShowShareFallback(false)}
-                className="grid h-8 w-8 place-items-center rounded-full bg-white text-[var(--muted)]"
-                aria-label="閉じる"
+                onClick={handleInviteFriends}
+                disabled={selectedInviteeIds.length === 0 || !canAccessParticipantActions}
+                className="flex w-full items-center justify-center gap-2 rounded-full bg-[var(--accent)] px-4 py-2 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:opacity-50"
               >
-                <span className="material-symbols-rounded">close</span>
+                <span className="material-symbols-rounded">send</span>
+                {event.visibility === "private" && userId !== event.owner.userId
+                  ? "選択したフレンドの招待を申請する"
+                  : "選択したフレンドを招待する"}
               </button>
-            </div>
 
-            <div className="mt-4 flex flex-col gap-3">
-              <p className="text-sm text-[var(--muted)]">このイベントを共有する</p>
-              <div className="grid grid-cols-1 gap-2">
-                <button
-                  onClick={() => {
-                    const url = inviteLink ?? `${window.location.origin}/events/${eventId}?ref=${userId ?? ""}`;
-                    const text = `このイベントに一緒に参加しませんか？ ${url}`;
-                    window.open(`https://line.me/R/msg/text/?${encodeURIComponent(text)}`);
-                    console.log("[DEBUG] LINE share clicked, url:", url);
-                  }}
-                  className="flex items-center justify-center gap-2 rounded-full bg-green-500 hover:bg-green-600 px-4 py-3 text-sm font-semibold text-white shadow-sm transition-colors"
-                >
-                  <span className="material-symbols-rounded">chat</span>
-                  LINEで共有
-                </button>
-                <button
-                  onClick={() => {
-                    const url = inviteLink ?? `${window.location.origin}/events/${eventId}?ref=${userId ?? ""}`;
-                    const text = `このイベントに一緒に参加しませんか？`;
-                    window.open(`https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(url)}`);
-                    console.log("[DEBUG] X (Twitter) share clicked, url:", url);
-                  }}
-                  className="flex items-center justify-center gap-2 rounded-full bg-black hover:bg-gray-800 px-4 py-3 text-sm font-semibold text-white shadow-sm transition-colors"
-                >
-                  <span className="material-symbols-rounded">share</span>
-                  Xで共有
-                </button>
-                <button
-                  onClick={() => {
-                    const url = inviteLink ?? `${window.location.origin}/events/${eventId}?ref=${userId ?? ""}`;
-                    try {
-                      navigator.clipboard.writeText(url);
-                      setInviteMessage("招待リンクをコピーしました。");
-                      console.log("[DEBUG] Link copied:", url);
-                    } catch (error) {
-                      console.log("[DEBUG] Copy failed:", error);
-                      setInviteMessage("コピーに失敗しました。リンクを長押しして共有してください。");
-                    }
-                    setShowShareFallback(false);
-                  }}
-                  className="flex items-center justify-center gap-2 rounded-full bg-white border-2 border-gray-300 hover:bg-gray-50 px-4 py-3 text-sm font-semibold text-[var(--foreground)] shadow-sm transition-colors"
-                >
-                  <span className="material-symbols-rounded">content_copy</span>
-                  リンクをコピー
-                </button>
-              </div>
+              <button
+                onClick={handleShare}
+                disabled={!canAccessParticipantActions}
+                className="flex w-full items-center justify-center gap-2 rounded-full bg-white border-2 border-gray-200 hover:bg-gray-50 px-4 py-2 text-sm font-semibold text-[var(--foreground)] disabled:cursor-not-allowed disabled:opacity-50 transition-colors"
+              >
+                <span className="material-symbols-rounded">share</span>
+                外部アプリで招待する
+              </button>
             </div>
           </div>
         </div>

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -826,7 +826,23 @@ export default function EventDetailPage() {
         await (navigator as any).share({ title: event.purpose, text, url: urlToShare });
       } catch (error) {
         const err = error as any;
-        if (err && err.name === "AbortError") {
+        const errMsg = err?.message || "";
+        const errName = err?.name || "";
+        const errStr = String(error);
+
+        const isUserCancellation =
+          errName === "AbortError" ||
+          errName === "NotAllowedError" ||
+          errMsg.includes("Share canceled") ||
+          errMsg.includes("canceled") ||
+          errMsg.includes("cancelled") ||
+          errMsg.includes("aborted") ||
+          errStr.includes("AbortError") ||
+          errStr.includes("canceled") ||
+          errStr.includes("cancelled") ||
+          errStr.includes("aborted");
+
+        if (isUserCancellation) {
           return;
         }
         if (!quiet) setInviteMessage("共有に失敗しました。");

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -814,7 +814,11 @@ export default function EventDetailPage() {
     if (!event) return;
 
     // Ensure we have an invite link (server-backed token) so tracking works.
-    const createdInviteLink = !inviteLink && userId ? await handleCreateInviteLink(true) : null;
+    // Only attempt to create a server-backed invite token if the user has permissions (owner or approved)
+    const createdInviteLink =
+      !inviteLink && canAccessParticipantActions
+        ? await handleCreateInviteLink(true)
+        : null;
     const urlToShare =
       inviteLink ??
       createdInviteLink ??
@@ -853,7 +857,14 @@ export default function EventDetailPage() {
     // Fallback: Copy link to clipboard
     try {
       await navigator.clipboard.writeText(`${text} ${urlToShare}`);
-      if (!quiet) setInviteMessage("招待リンクをコピーしました。");
+      if (!quiet) {
+        const isInviteTokenLink = Boolean(inviteLink || createdInviteLink);
+        setInviteMessage(
+          isInviteTokenLink
+            ? "招待リンクをコピーしました。"
+            : "イベントのリンクをコピーしました。"
+        );
+      }
     } catch (error) {
       if (!quiet) setInviteMessage("コピーに失敗しました。リンクを長押しして共有してください。");
     }


### PR DESCRIPTION
    ## 概要
    Web Share
  APIを使用してイベント共有を行う際、共有オーバーレイを送信せずにキャンセル（オーバーレイ外をタップして閉じるなど）した場合に、エラーメッ
  セージ（「共有に失敗しました。」）が表示されてしまう問題を修正しました。

    ## 変更内容
    - [app/events/[id]/page.tsx](file:///home/shinnosuke-tatsukawa/Meet-develop/meet-moc/app/events/[id]/page.tsx) の `handleShare`
  関数において、`navigator.share` が投げる例外が
  `AbortError`（ユーザーによるキャンセル）である場合は、エラーメッセージを設定せずに早期リターンするように修正しました。

    ## 影響範囲
    - イベント詳細画面の「共有」ボタン
    - 招待ポップアップの「外部アプリで招待する」ボタン