### PR TITLE
イベント承認フローにおけるプライベートイベントの承認ロジックの修正

### DIFF
--- a/app/api/events/[id]/join/route.ts
+++ b/app/api/events/[id]/join/route.ts
@@ -3,7 +3,6 @@ import { prisma } from "@/lib/prisma";
 import { syncApprovedEventFriendships } from "@/lib/event-friendships";
 import { createAppNotification } from "@/lib/notification-delivery";
 import {
-  needsOwnerApprovalByDeadline,
   shouldAutoApprove,
 } from "@/lib/event-approval";
 

--- a/app/api/events/[id]/join/route.ts
+++ b/app/api/events/[id]/join/route.ts
@@ -2,6 +2,10 @@ import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { syncApprovedEventFriendships } from "@/lib/event-friendships";
 import { createAppNotification } from "@/lib/notification-delivery";
+import {
+  needsOwnerApprovalByDeadline,
+  shouldAutoApprove,
+} from "@/lib/event-approval";
 
 const needsOwnerApprovalByDeadline = (event: {
   scheduleMode: "fixed" | "candidate";
@@ -91,16 +95,20 @@ export async function POST(
   const isInvitedByOwner =
     pendingInvite && pendingInvite.inviterId === event.ownerId;
 
-  const overCapacity = approvedCount >= event.capacity;
-  const requiresApprovalByDeadline = needsOwnerApprovalByDeadline(event);
-  const requiresApprovalByVisibility =
-    (event.visibility === "limited" || event.visibility === "private") &&
-    !isInvitedByOwner;
+  const shouldAuto = shouldAutoApprove(
+    {
+      scheduleMode: event.scheduleMode,
+      status: event.status,
+      fixedStartTime: event.fixedStartTime,
+      timeCandidates: event.timeCandidates ?? [],
+      visibility: event.visibility,
+      capacity: event.capacity,
+    },
+    Boolean(isInvitedByOwner),
+    approvedCount
+  );
 
-  const shouldAutoApprove =
-    !overCapacity && !requiresApprovalByDeadline && !requiresApprovalByVisibility;
-
-  const nextStatus = shouldAutoApprove ? "approved" : "requested";
+  const nextStatus = shouldAuto ? "approved" : "requested";
 
   if (pendingInvite) {
     await prisma.eventInvite.update({

--- a/app/api/events/[id]/join/route.ts
+++ b/app/api/events/[id]/join/route.ts
@@ -7,46 +7,7 @@ import {
   shouldAutoApprove,
 } from "@/lib/event-approval";
 
-const needsOwnerApprovalByDeadline = (event: {
-  scheduleMode: "fixed" | "candidate";
-  status: "open" | "confirmed" | "completed" | "cancelled";
-  fixedStartTime: Date | null;
-  timeCandidates: Array<{ startTime: Date }>;
-}) => {
-  const now = Date.now();
 
-  if (event.status === "cancelled") {
-    return true;
-  }
-
-  if (event.scheduleMode === "fixed") {
-    if (!event.fixedStartTime) {
-      return false;
-    }
-    const deadline = new Date(event.fixedStartTime);
-    deadline.setDate(deadline.getDate() - 1);
-    return now > deadline.getTime();
-  }
-
-  if (event.status !== "open") {
-    return true;
-  }
-
-  const candidateStarts = event.timeCandidates
-    .map((candidate) => candidate.startTime.getTime())
-    .filter((timestamp) => Number.isFinite(timestamp));
-
-  const firstStart =
-    event.fixedStartTime != null
-      ? event.fixedStartTime.getTime()
-      : candidateStarts.length > 0
-        ? Math.min(...candidateStarts)
-        : now + 7 * 24 * 60 * 60 * 1000;
-
-  const deadline = new Date(firstStart);
-  deadline.setDate(deadline.getDate() - 1);
-  return now > deadline.getTime();
-};
 
 export async function POST(
   request: Request,

--- a/lib/event-approval.ts
+++ b/lib/event-approval.ts
@@ -1,0 +1,61 @@
+export type TimeCandidate = { startTime: Date };
+
+export type ApprovalEvent = {
+  scheduleMode: "fixed" | "candidate";
+  status: "open" | "confirmed" | "completed" | "cancelled";
+  fixedStartTime: Date | null;
+  timeCandidates: TimeCandidate[];
+  visibility?: string | null;
+  capacity?: number | null;
+};
+
+export const needsOwnerApprovalByDeadline = (event: ApprovalEvent) => {
+  const now = Date.now();
+
+  if (event.status === "cancelled") {
+    return true;
+  }
+
+  if (event.scheduleMode === "fixed") {
+    if (!event.fixedStartTime) {
+      return false;
+    }
+    const deadline = new Date(event.fixedStartTime);
+    deadline.setDate(deadline.getDate() - 1);
+    return now > deadline.getTime();
+  }
+
+  if (event.status !== "open") {
+    return true;
+  }
+
+  const candidateStarts = event.timeCandidates
+    .map((candidate) => candidate.startTime.getTime())
+    .filter((timestamp) => Number.isFinite(timestamp));
+
+  const firstStart =
+    event.fixedStartTime != null
+      ? event.fixedStartTime.getTime()
+      : candidateStarts.length > 0
+      ? Math.min(...candidateStarts)
+      : now + 7 * 24 * 60 * 60 * 1000;
+
+  const deadline = new Date(firstStart);
+  deadline.setDate(deadline.getDate() - 1);
+  return now > deadline.getTime();
+};
+
+export const shouldAutoApprove = (
+  event: ApprovalEvent,
+  isInvitedByOwner: boolean,
+  approvedCount: number
+) => {
+  const overCapacity = (event.capacity ?? Infinity) <= approvedCount;
+  const requiresApprovalByDeadline = needsOwnerApprovalByDeadline(event);
+  const requiresApprovalByVisibility = event.visibility === "private" && !isInvitedByOwner;
+
+  return !overCapacity && !requiresApprovalByDeadline && !requiresApprovalByVisibility;
+};
+
+export const requiresApprovalByVisibility = (event: ApprovalEvent, isInvitedByOwner: boolean) =>
+  event.visibility === "private" && !isInvitedByOwner;

--- a/tests/event-approval.test.ts
+++ b/tests/event-approval.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { shouldAutoApprove, requiresApprovalByVisibility } from "../lib/event-approval";
+
+const baseEvent = {
+  scheduleMode: "candidate" as const,
+  status: "open" as const,
+  fixedStartTime: null,
+  timeCandidates: [] as Array<{ startTime: Date }> ,
+  capacity: 10,
+};
+
+{
+  const ev = { ...baseEvent, visibility: "private" };
+  const auto = shouldAutoApprove(ev, false, 0);
+  assert.equal(auto, false, "private イベントかつ招待なしでは自動承認されない");
+  assert.equal(requiresApprovalByVisibility(ev, false), true, "private かつ未招待は承認が必要");
+  console.log("[PASS] private visibility requires approval when not invited");
+}
+
+{
+  const ev = { ...baseEvent, visibility: "public" };
+  const auto = shouldAutoApprove(ev, false, 0);
+  assert.equal(auto, true, "public イベントでは自動承認される");
+  console.log("[PASS] public visibility auto-approves");
+}
+
+{
+  const ev = { ...baseEvent, visibility: "private" };
+  const auto = shouldAutoApprove(ev, true, 0);
+  assert.equal(auto, true, "オーナー招待なら private でも自動承認される");
+  console.log("[PASS] invited by owner bypasses private approval");
+}
+
+console.log("All event approval tests passed.");


### PR DESCRIPTION
## 概要
<!-- PR 作成経緯が分かるように関連リンクや画像をつけながら記載する -->

イベントの承認の際に公開イベントの場合も承認が必要になってしまっている。この状態を修正したい。

**関連ドキュメント**
<!-- 関連するファイルや参考にした記事のリンクを記載する -->
- #53

## 影響範囲
<!-- 本番環境の利用者への影響はあるかどうか(特にDBのマイギュレーションなどの操作を実施しているかどうか
)-->
- 承認が必要になる幅が変更前より狭くなる

## 変更点

**AS IS**
<!-- 変更前の状態を記載する -->
- 公開イベントでもイベント参加の承認が必要になっていた。

**TO BE**
<!-- 変更後の状態を記載する -->
- プライベートイベントのみにイベント参加の承認が必要になる。

## QA 観点
<!-- 修正内容により期待される結果を記載する。修正内容による影響範囲や懸念点についても記載する -->
- 公開イベントに参加する際は、承認がない
- プライベートに参加する際には、承認の必要が出てくる。

## 動作確認ケース
<!-- レビュアーが確認しやすいように AsIs-ToBe のキャプチャを貼るなどコミューケーションコストを下げる工夫をする -->
- text

## レビュアーに特に見て欲しいポイント
<!-- 特に見て欲しいポイントがあれば明記する -->
- 特になし
