### PR TITLE
feat: 場所・日程オーバーレイに候補一覧とカテゴリーフィルターを追加 (#54)

### DIFF
--- a/app/api/events/[id]/candidates/place/[candidateId]/route.ts
+++ b/app/api/events/[id]/candidates/place/[candidateId]/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ id: string; candidateId: string }> }
+) {
+  const { id, candidateId } = await params;
+  const body = (await request.json()) as { userId?: string };
+
+  if (!body.userId) {
+    return NextResponse.json({ message: "userId is required" }, { status: 400 });
+  }
+
+  const [event, candidate] = await Promise.all([
+    prisma.event.findUnique({
+      where: { id },
+      select: { status: true, ownerId: true },
+    }),
+    prisma.eventPlaceCandidate.findUnique({
+      where: { id: candidateId },
+      select: { eventId: true, proposedBy: true },
+    }),
+  ]);
+
+  if (!event || !candidate || candidate.eventId !== id) {
+    return NextResponse.json({ message: "Not found" }, { status: 404 });
+  }
+
+  if (event.status !== "open") {
+    return NextResponse.json(
+      { message: "Only open events can have candidates removed" },
+      { status: 400 }
+    );
+  }
+
+  const isOwner = event.ownerId === body.userId;
+  const isProposer = candidate.proposedBy === body.userId;
+
+  if (!isOwner && !isProposer) {
+    return NextResponse.json({ message: "Not authorized" }, { status: 403 });
+  }
+
+  await prisma.eventPlaceCandidate.delete({ where: { id: candidateId } });
+
+  return NextResponse.json({ success: true });
+}

--- a/app/api/events/[id]/candidates/time/[candidateId]/route.ts
+++ b/app/api/events/[id]/candidates/time/[candidateId]/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ id: string; candidateId: string }> }
+) {
+  const { id, candidateId } = await params;
+  const body = (await request.json()) as { userId?: string };
+
+  if (!body.userId) {
+    return NextResponse.json({ message: "userId is required" }, { status: 400 });
+  }
+
+  const [event, candidate] = await Promise.all([
+    prisma.event.findUnique({
+      where: { id },
+      select: { status: true, ownerId: true },
+    }),
+    prisma.eventTimeCandidate.findUnique({
+      where: { id: candidateId },
+      select: { eventId: true, proposedBy: true },
+    }),
+  ]);
+
+  if (!event || !candidate || candidate.eventId !== id) {
+    return NextResponse.json({ message: "Not found" }, { status: 404 });
+  }
+
+  if (event.status !== "open") {
+    return NextResponse.json(
+      { message: "Only open events can have candidates removed" },
+      { status: 400 }
+    );
+  }
+
+  const isOwner = event.ownerId === body.userId;
+  const isProposer = candidate.proposedBy === body.userId;
+
+  if (!isOwner && !isProposer) {
+    return NextResponse.json({ message: "Not authorized" }, { status: 403 });
+  }
+
+  await prisma.eventTimeCandidate.delete({ where: { id: candidateId } });
+
+  return NextResponse.json({ success: true });
+}

--- a/app/api/events/[id]/route.ts
+++ b/app/api/events/[id]/route.ts
@@ -163,8 +163,8 @@ export async function GET(
         myAvailability: myVote?.isAvailable ?? null,
       };
     })
-    .sort((a: any, b: any) => b.score - a.score)
-    .slice(0, 3);
+    .sort((a: any, b: any) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime())
+    .slice(0, 5);
 
   const placeCandidates = (
     await Promise.all(

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -729,6 +729,39 @@ export default function EventDetailPage() {
     }
   };
 
+  const canDeleteCandidate = (candidate: { proposedBy?: string | null }) =>
+    !candidateActionsDisabled && (isOwner || (userId !== null && candidate.proposedBy === userId));
+
+  const handleDeleteTimeCandidate = async (candidateId: string) => {
+    if (!userId || !event) return;
+    await fetch(`/api/events/${eventId}/candidates/time/${candidateId}`, {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ userId }),
+    });
+    const query = userId ? `?viewerId=${userId}` : "";
+    const response = await fetch(`/api/events/${eventId}${query}`, { cache: "no-store" });
+    if (response.ok) {
+      const data = (await response.json()) as EventDetail;
+      setEvent(data);
+    }
+  };
+
+  const handleDeletePlaceCandidate = async (candidateId: string) => {
+    if (!userId || !event) return;
+    await fetch(`/api/events/${eventId}/candidates/place/${candidateId}`, {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ userId }),
+    });
+    const query = userId ? `?viewerId=${userId}` : "";
+    const response = await fetch(`/api/events/${eventId}${query}`, { cache: "no-store" });
+    if (response.ok) {
+      const data = (await response.json()) as EventDetail;
+      setEvent(data);
+    }
+  };
+
   const handlePlaceSearch = async () => {
     if (!placeQuery.trim()) return;
     const response = await fetch(`/api/places/search?query=${encodeURIComponent(placeQuery)}`);
@@ -1113,7 +1146,16 @@ export default function EventDetailPage() {
               </h2>
               <ul className="mt-4 grid gap-3 text-sm text-[var(--muted)] md:grid-cols-2">
                 {event.timeCandidates.map((candidate) => (
-                  <li key={candidate.id} className="rounded-2xl bg-white p-4 shadow-sm">
+                  <li key={candidate.id} className="relative rounded-2xl bg-white p-4 shadow-sm">
+                    {canDeleteCandidate(candidate) && (
+                      <button
+                        onClick={() => handleDeleteTimeCandidate(candidate.id)}
+                        className="absolute left-2 top-2 grid h-5 w-5 place-items-center rounded-full bg-gray-100 text-gray-400 hover:bg-rose-100 hover:text-rose-500"
+                        aria-label="候補を削除"
+                      >
+                        <span className="material-symbols-rounded text-xs">close</span>
+                      </button>
+                    )}
                     <div className="flex items-center gap-3">
                       <p className="min-w-0 flex-1 truncate font-semibold text-[var(--foreground)]">
                         {formatStart(candidate.startTime)}
@@ -1181,7 +1223,16 @@ export default function EventDetailPage() {
               </h2>
               <ul className="mt-4 grid gap-3 text-sm text-[var(--muted)] md:grid-cols-2">
                 {event.placeCandidates.map((candidate) => (
-                  <li key={candidate.id} className="overflow-hidden rounded-2xl bg-white p-4 shadow-sm">
+                  <li key={candidate.id} className="relative overflow-hidden rounded-2xl bg-white p-4 shadow-sm">
+                    {canDeleteCandidate(candidate) && (
+                      <button
+                        onClick={() => handleDeletePlaceCandidate(candidate.id)}
+                        className="absolute left-2 top-2 grid h-5 w-5 place-items-center rounded-full bg-gray-100 text-gray-400 hover:bg-rose-100 hover:text-rose-500"
+                        aria-label="候補を削除"
+                      >
+                        <span className="material-symbols-rounded text-xs">close</span>
+                      </button>
+                    )}
                     <div className="flex min-w-0 items-center gap-3">
                       <button
                         onClick={() => setSelectedPlaceDetail(candidate)}

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -1138,7 +1138,7 @@ export default function EventDetailPage() {
                 </button>
                 <span className="inline-flex items-center gap-1 rounded-full bg-sky-100 px-2 py-1 text-[10px] font-semibold tracking-[0.08em] text-sky-700">
                   <span className="material-symbols-rounded text-sm">auto_awesome</span>
-                  AI推測 TOP3
+                  最大5件・日付順
                 </span>
               </h2>
               <ul className="mt-4 grid gap-3 text-sm text-[var(--muted)] md:grid-cols-2">
@@ -1379,7 +1379,7 @@ export default function EventDetailPage() {
             {dateSuggestions.length > 0 && (
               <div className="mt-4">
                 <p className="mb-2 text-xs font-semibold text-[var(--muted)]">候補日程</p>
-                <ul className="grid grid-cols-2 gap-2">
+                <ul className="space-y-2">
                   {dateSuggestions.map((dateStr) => {
                     const date = new Date(dateStr);
                     const weekday = ["日", "月", "火", "水", "木", "金", "土"][date.getDay()];
@@ -1389,15 +1389,15 @@ export default function EventDetailPage() {
                       <li key={dateStr}>
                         <button
                           onClick={() => handleTimeProposal(dateStr)}
-                          className="flex w-full items-center gap-2 rounded-2xl bg-white px-3 py-2.5 text-left shadow-sm hover:bg-orange-50"
+                          className="flex w-full items-center gap-3 rounded-2xl bg-white p-4 text-left shadow-sm hover:bg-orange-50"
                         >
-                          <div className="flex h-9 w-9 shrink-0 flex-col items-center justify-center rounded-xl bg-orange-50">
+                          <div className="flex h-10 w-10 shrink-0 flex-col items-center justify-center rounded-xl bg-orange-50">
                             <span className="text-[9px] font-semibold text-[var(--accent)]">{month}月</span>
-                            <span className="text-sm font-bold leading-none text-[var(--accent)]">{day}</span>
+                            <span className="text-base font-bold leading-none text-[var(--accent)]">{day}</span>
                           </div>
                           <div className="min-w-0">
-                            <p className="text-xs font-semibold text-[var(--foreground)]">{weekday}曜日</p>
-                            <p className="text-[10px] text-[var(--muted)]">18:00〜</p>
+                            <p className="font-semibold text-[var(--foreground)]">{weekday}曜日</p>
+                            <p className="text-xs text-[var(--muted)]">18:00〜</p>
                           </div>
                         </button>
                       </li>

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -122,11 +122,6 @@ function generateWeekendSuggestions(existingStartTimes: string[]): string[] {
   return suggestions;
 }
 
-function formatDateChip(localDateStr: string): string {
-  const date = new Date(localDateStr);
-  const weekday = ["日", "月", "火", "水", "木", "金", "土"][date.getDay()];
-  return `${weekday} ${date.getMonth() + 1}/${date.getDate()}`;
-}
 
 const formatStart = (start?: string | null) => {
   if (!start) return "未確定";
@@ -459,7 +454,7 @@ export default function EventDetailPage() {
     const baseQuery = [event.area, event.purpose].filter(Boolean).join(" ") || "東京";
     const query = [baseQuery, category].filter(Boolean).join(" ");
     const response = await fetch(
-      `/api/places/search?query=${encodeURIComponent(query)}&limit=5`
+      `/api/places/search?query=${encodeURIComponent(query)}&limit=10`
     );
     if (response.ok) {
       const data = (await response.json()) as { places: PlaceResult[] };
@@ -1150,10 +1145,10 @@ export default function EventDetailPage() {
                     {canDeleteCandidate(candidate) && (
                       <button
                         onClick={() => handleDeleteTimeCandidate(candidate.id)}
-                        className="absolute left-4 top-4 z-10 flex h-5 w-5 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full bg-gray-400 text-white hover:bg-rose-500"
+                        className="absolute left-2 top-2 z-10 flex h-5 w-5 items-center justify-center rounded-full bg-gray-400 text-white hover:bg-rose-500"
                         aria-label="候補を削除"
                       >
-                        <span className="material-symbols-rounded leading-none" style={{ fontSize: "8px" }}>close</span>
+                        <span className="material-symbols-rounded leading-none" style={{ fontSize: "16px" }}>close</span>
                       </button>
                     )}
                     <div className="flex items-center gap-3">
@@ -1227,10 +1222,10 @@ export default function EventDetailPage() {
                     {canDeleteCandidate(candidate) && (
                       <button
                         onClick={() => handleDeletePlaceCandidate(candidate.id)}
-                        className="absolute left-4 top-4 z-10 flex h-5 w-5 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full bg-gray-400 text-white hover:bg-rose-500"
+                        className="absolute left-2 top-2 z-10 flex h-5 w-5 items-center justify-center rounded-full bg-gray-400 text-white hover:bg-rose-500"
                         aria-label="候補を削除"
                       >
-                        <span className="material-symbols-rounded leading-none" style={{ fontSize: "8px" }}>close</span>
+                        <span className="material-symbols-rounded leading-none" style={{ fontSize: "16px" }}>close</span>
                       </button>
                     )}
                     <div className="flex min-w-0 items-center gap-3">
@@ -1382,17 +1377,31 @@ export default function EventDetailPage() {
             {dateSuggestions.length > 0 && (
               <div className="mt-4">
                 <p className="mb-2 text-xs font-semibold text-[var(--muted)]">候補日程</p>
-                <div className="flex flex-wrap gap-2">
-                  {dateSuggestions.map((dateStr) => (
-                    <button
-                      key={dateStr}
-                      onClick={() => handleTimeProposal(dateStr)}
-                      className="rounded-full bg-white px-3 py-1.5 text-xs font-semibold text-[var(--foreground)] shadow-sm hover:bg-orange-50 hover:text-[var(--accent)]"
-                    >
-                      {formatDateChip(dateStr)}
-                    </button>
-                  ))}
-                </div>
+                <ul className="grid grid-cols-2 gap-2">
+                  {dateSuggestions.map((dateStr) => {
+                    const date = new Date(dateStr);
+                    const weekday = ["日", "月", "火", "水", "木", "金", "土"][date.getDay()];
+                    const month = date.getMonth() + 1;
+                    const day = date.getDate();
+                    return (
+                      <li key={dateStr}>
+                        <button
+                          onClick={() => handleTimeProposal(dateStr)}
+                          className="flex w-full items-center gap-2 rounded-2xl bg-white px-3 py-2.5 text-left shadow-sm hover:bg-orange-50"
+                        >
+                          <div className="flex h-9 w-9 shrink-0 flex-col items-center justify-center rounded-xl bg-orange-50">
+                            <span className="text-[9px] font-semibold text-[var(--accent)]">{month}月</span>
+                            <span className="text-sm font-bold leading-none text-[var(--accent)]">{day}</span>
+                          </div>
+                          <div className="min-w-0">
+                            <p className="text-xs font-semibold text-[var(--foreground)]">{weekday}曜日</p>
+                            <p className="text-[10px] text-[var(--muted)]">18:00〜</p>
+                          </div>
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
               </div>
             )}
 

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -1150,10 +1150,10 @@ export default function EventDetailPage() {
                     {canDeleteCandidate(candidate) && (
                       <button
                         onClick={() => handleDeleteTimeCandidate(candidate.id)}
-                        className="absolute left-1 top-1 z-10 flex h-5 w-5 items-center justify-center rounded-full bg-gray-400 text-white hover:bg-rose-500"
+                        className="absolute left-0 top-0 z-10 flex h-5 w-5 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full bg-gray-400 text-white hover:bg-rose-500"
                         aria-label="候補を削除"
                       >
-                        <span className="material-symbols-rounded text-[12px] leading-none">close</span>
+                        <span className="material-symbols-rounded text-[10px] leading-none">close</span>
                       </button>
                     )}
                     <div className="flex items-center gap-3">
@@ -1227,10 +1227,10 @@ export default function EventDetailPage() {
                     {canDeleteCandidate(candidate) && (
                       <button
                         onClick={() => handleDeletePlaceCandidate(candidate.id)}
-                        className="absolute left-1 top-1 z-10 flex h-5 w-5 items-center justify-center rounded-full bg-gray-400 text-white hover:bg-rose-500"
+                        className="absolute left-0 top-0 z-10 flex h-5 w-5 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full bg-gray-400 text-white hover:bg-rose-500"
                         aria-label="候補を削除"
                       >
-                        <span className="material-symbols-rounded text-[12px] leading-none">close</span>
+                        <span className="material-symbols-rounded text-[10px] leading-none">close</span>
                       </button>
                     )}
                     <div className="flex min-w-0 items-center gap-3">

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -92,6 +92,42 @@ type PlaceResult = {
 const plusButtonClass =
   "grid h-7 w-7 place-items-center rounded-full border border-dashed border-gray-400 bg-gray-50 text-gray-500";
 
+const PLACE_CATEGORIES = ["居酒屋", "カフェ", "レストラン", "バー", "焼肉"];
+
+function generateWeekendSuggestions(existingStartTimes: string[]): string[] {
+  const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
+  const existingDates = new Set(
+    existingStartTimes.map((iso) => {
+      const jst = new Date(new Date(iso).getTime() + JST_OFFSET_MS);
+      return `${jst.getUTCFullYear()}-${String(jst.getUTCMonth() + 1).padStart(2, "0")}-${String(jst.getUTCDate()).padStart(2, "0")}`;
+    })
+  );
+  const suggestions: string[] = [];
+  const cursor = new Date();
+  cursor.setDate(cursor.getDate() + 1);
+  cursor.setHours(0, 0, 0, 0);
+  while (suggestions.length < 5) {
+    const dow = cursor.getDay();
+    if (dow === 0 || dow === 6) {
+      const y = cursor.getFullYear();
+      const m = String(cursor.getMonth() + 1).padStart(2, "0");
+      const d = String(cursor.getDate()).padStart(2, "0");
+      const dateStr = `${y}-${m}-${d}`;
+      if (!existingDates.has(dateStr)) {
+        suggestions.push(`${dateStr}T18:00`);
+      }
+    }
+    cursor.setDate(cursor.getDate() + 1);
+  }
+  return suggestions;
+}
+
+function formatDateChip(localDateStr: string): string {
+  const date = new Date(localDateStr);
+  const weekday = ["日", "月", "火", "水", "木", "金", "土"][date.getDay()];
+  return `${weekday} ${date.getMonth() + 1}/${date.getDate()}`;
+}
+
 const formatStart = (start?: string | null) => {
   if (!start) return "未確定";
   return formatEventStartLabel(start, true);
@@ -194,6 +230,10 @@ export default function EventDetailPage() {
 
   const [placeQuery, setPlaceQuery] = useState("");
   const [placeResults, setPlaceResults] = useState<PlaceResult[]>([]);
+  const [suggestedPlaces, setSuggestedPlaces] = useState<PlaceResult[]>([]);
+  const [placeCategory, setPlaceCategory] = useState("");
+  const [isSuggestionsLoading, setIsSuggestionsLoading] = useState(false);
+  const [dateSuggestions, setDateSuggestions] = useState<string[]>([]);
   const [showTimeOverlay, setShowTimeOverlay] = useState(false);
   const [showPlaceOverlay, setShowPlaceOverlay] = useState(false);
   const [selectedPlaceDetail, setSelectedPlaceDetail] = useState<EventDetail["placeCandidates"][number] | null>(null);
@@ -408,7 +448,24 @@ export default function EventDetailPage() {
       setInviteMessage(participantActionNotice);
       return;
     }
+    const existing = event?.timeCandidates.map((c) => c.startTime) ?? [];
+    setDateSuggestions(generateWeekendSuggestions(existing));
     setShowTimeOverlay(true);
+  };
+
+  const fetchPlaceSuggestions = async (category = "") => {
+    if (!event) return;
+    setIsSuggestionsLoading(true);
+    const baseQuery = event.area ?? event.purpose ?? "東京";
+    const query = [baseQuery, category].filter(Boolean).join(" ");
+    const response = await fetch(
+      `/api/places/search?query=${encodeURIComponent(query)}&limit=5`
+    );
+    if (response.ok) {
+      const data = (await response.json()) as { places: PlaceResult[] };
+      setSuggestedPlaces(data.places ?? []);
+    }
+    setIsSuggestionsLoading(false);
   };
 
   const openPlaceProposalOverlay = () => {
@@ -421,7 +478,10 @@ export default function EventDetailPage() {
       setInviteMessage(participantActionNotice);
       return;
     }
+    setPlaceCategory("");
+    setSuggestedPlaces([]);
     setShowPlaceOverlay(true);
+    void fetchPlaceSuggestions();
   };
 
   const statusMeta = useMemo(() => {
@@ -702,6 +762,8 @@ export default function EventDetailPage() {
       setShowPlaceOverlay(false);
       setPlaceQuery("");
       setPlaceResults([]);
+      setSuggestedPlaces([]);
+      setPlaceCategory("");
     }
   };
 
@@ -1254,7 +1316,7 @@ export default function EventDetailPage() {
 
       {showTimeOverlay && (
         <div className="fixed inset-0 z-[60] flex items-end bg-black/35 p-3 sm:items-center sm:justify-center sm:p-6">
-          <div className="w-full max-w-md rounded-3xl bg-[var(--surface)] p-4 shadow-2xl">
+          <div className="max-h-[85vh] w-full max-w-md overflow-y-auto rounded-3xl bg-[var(--surface)] p-4 shadow-2xl">
             <div className="flex items-center justify-between">
               <h3 className="text-base font-semibold">別の日程を提案</h3>
               <button
@@ -1265,7 +1327,31 @@ export default function EventDetailPage() {
                 <span className="material-symbols-rounded">close</span>
               </button>
             </div>
-            <div className="mt-4 flex flex-col gap-2">
+
+            {dateSuggestions.length > 0 && (
+              <div className="mt-4">
+                <p className="mb-2 text-xs font-semibold text-[var(--muted)]">候補日程</p>
+                <div className="flex flex-wrap gap-2">
+                  {dateSuggestions.map((dateStr) => (
+                    <button
+                      key={dateStr}
+                      onClick={() => handleTimeProposal(dateStr)}
+                      className="rounded-full bg-white px-3 py-1.5 text-xs font-semibold text-[var(--foreground)] shadow-sm hover:bg-orange-50 hover:text-[var(--accent)]"
+                    >
+                      {formatDateChip(dateStr)}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            <div className="mt-4 flex items-center gap-2">
+              <div className="h-px flex-1 bg-gray-200" />
+              <p className="text-xs text-[var(--muted)]">またはカスタム日時</p>
+              <div className="h-px flex-1 bg-gray-200" />
+            </div>
+
+            <div className="mt-3 flex flex-col gap-2">
               <input
                 type="datetime-local"
                 value={proposalStart}
@@ -1286,7 +1372,7 @@ export default function EventDetailPage() {
 
       {showPlaceOverlay && (
         <div className="fixed inset-0 z-[60] flex items-end bg-black/35 p-3 sm:items-center sm:justify-center sm:p-6">
-          <div className="w-full max-w-md rounded-3xl bg-[var(--surface)] p-4 shadow-2xl">
+          <div className="max-h-[85vh] w-full max-w-md overflow-y-auto rounded-3xl bg-[var(--surface)] p-4 shadow-2xl">
             <div className="flex items-center justify-between">
               <h3 className="text-base font-semibold">場所を提案</h3>
               <button
@@ -1297,7 +1383,73 @@ export default function EventDetailPage() {
                 <span className="material-symbols-rounded">close</span>
               </button>
             </div>
-            <div className="mt-4 flex flex-col gap-2">
+
+            <div className="mt-3 flex flex-wrap gap-1.5">
+              {PLACE_CATEGORIES.map((cat) => (
+                <button
+                  key={cat}
+                  onClick={() => {
+                    const next = placeCategory === cat ? "" : cat;
+                    setPlaceCategory(next);
+                    void fetchPlaceSuggestions(next);
+                  }}
+                  className={`rounded-full px-3 py-1 text-xs font-semibold ${
+                    placeCategory === cat
+                      ? "bg-[var(--accent)] text-white"
+                      : "bg-white text-[var(--foreground)] shadow-sm"
+                  }`}
+                >
+                  {cat}
+                </button>
+              ))}
+            </div>
+
+            <div className="mt-3">
+              <p className="mb-2 text-xs font-semibold text-[var(--muted)]">おすすめ</p>
+              {isSuggestionsLoading ? (
+                <p className="py-3 text-center text-xs text-[var(--muted)]">読み込み中...</p>
+              ) : suggestedPlaces.length > 0 ? (
+                <ul className="space-y-2 text-sm">
+                  {suggestedPlaces.map((place) => (
+                    <li
+                      key={place.placeId}
+                      className="flex flex-col gap-2 rounded-2xl bg-white px-3 py-2 shadow-sm sm:flex-row sm:items-center sm:justify-between"
+                    >
+                      <div className="min-w-0 flex items-center gap-2">
+                        <Image
+                          src={place.photoUrl ?? "/file.svg"}
+                          alt={`${place.name} の写真`}
+                          width={40}
+                          height={40}
+                          className="h-10 w-10 rounded-xl object-cover"
+                        />
+                        <div className="min-w-0">
+                          <p className="truncate text-sm font-semibold text-[var(--foreground)]">{place.name}</p>
+                          <p className="truncate text-xs text-[var(--muted)]">{place.address}</p>
+                        </div>
+                      </div>
+                      <button
+                        onClick={() => handlePlaceProposal(place)}
+                        className="flex w-full items-center justify-center gap-1 rounded-full bg-orange-100 px-3 py-1 text-xs font-semibold text-[var(--accent)] sm:w-auto"
+                      >
+                        <span className="material-symbols-rounded">add</span>
+                        追加
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="py-2 text-center text-xs text-[var(--muted)]">候補が見つかりませんでした</p>
+              )}
+            </div>
+
+            <div className="mt-4 flex items-center gap-2">
+              <div className="h-px flex-1 bg-gray-200" />
+              <p className="text-xs text-[var(--muted)]">他の場所を探す</p>
+              <div className="h-px flex-1 bg-gray-200" />
+            </div>
+
+            <div className="mt-3 flex flex-col gap-2">
               <div className="flex flex-col gap-2 sm:flex-row">
                 <input
                   value={placeQuery}
@@ -1315,7 +1467,7 @@ export default function EventDetailPage() {
               </div>
 
               {placeResults.length > 0 && (
-                <ul className="max-h-64 space-y-2 overflow-y-auto pr-1 text-sm">
+                <ul className="max-h-48 space-y-2 overflow-y-auto pr-1 text-sm">
                   {placeResults.map((place) => (
                     <li
                       key={place.placeId}

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -1150,7 +1150,7 @@ export default function EventDetailPage() {
                     {canDeleteCandidate(candidate) && (
                       <button
                         onClick={() => handleDeleteTimeCandidate(candidate.id)}
-                        className="absolute -left-2.5 -top-2.5 z-10 flex h-5 w-5 items-center justify-center rounded-full bg-gray-100 text-gray-400 hover:bg-rose-100 hover:text-rose-500"
+                        className="absolute left-1 top-1 z-10 flex h-5 w-5 items-center justify-center rounded-full bg-gray-400 text-white hover:bg-rose-500"
                         aria-label="候補を削除"
                       >
                         <span className="material-symbols-rounded text-[12px] leading-none">close</span>
@@ -1227,7 +1227,7 @@ export default function EventDetailPage() {
                     {canDeleteCandidate(candidate) && (
                       <button
                         onClick={() => handleDeletePlaceCandidate(candidate.id)}
-                        className="absolute -left-2.5 -top-2.5 z-10 flex h-5 w-5 items-center justify-center rounded-full bg-gray-100 text-gray-400 hover:bg-rose-100 hover:text-rose-500"
+                        className="absolute left-1 top-1 z-10 flex h-5 w-5 items-center justify-center rounded-full bg-gray-400 text-white hover:bg-rose-500"
                         aria-label="候補を削除"
                       >
                         <span className="material-symbols-rounded text-[12px] leading-none">close</span>
@@ -1459,9 +1459,9 @@ export default function EventDetailPage() {
               <p className="mb-2 text-xs font-semibold text-[var(--muted)]">おすすめ</p>
               {isSuggestionsLoading ? (
                 <p className="py-3 text-center text-xs text-[var(--muted)]">読み込み中...</p>
-              ) : suggestedPlaces.length > 0 ? (
+              ) : suggestedPlaces.filter((p) => !event.placeCandidates.some((c) => c.placeId === p.placeId)).length > 0 ? (
                 <ul className="space-y-2 text-sm">
-                  {suggestedPlaces.map((place) => (
+                  {suggestedPlaces.filter((p) => !event.placeCandidates.some((c) => c.placeId === p.placeId)).map((place) => (
                     <li key={place.placeId}>
                       <button
                         onClick={() => handlePlaceProposal(place)}
@@ -1512,7 +1512,7 @@ export default function EventDetailPage() {
 
               {placeResults.length > 0 && (
                 <ul className="max-h-48 space-y-2 overflow-y-auto pr-1 text-sm">
-                  {placeResults.map((place) => (
+                  {placeResults.filter((p) => !event.placeCandidates.some((c) => c.placeId === p.placeId)).map((place) => (
                     <li key={place.placeId}>
                       <button
                         onClick={() => handlePlaceProposal(place)}

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -1126,7 +1126,7 @@ export default function EventDetailPage() {
             )}
             {needsTimeCandidates && (
               <div>
-              <h2 className="flex items-center gap-2 text-lg font-semibold">
+              <h2 className="flex w-full items-center gap-2 text-lg font-semibold">
                 日程候補
                 <button
                   onClick={openTimeProposalOverlay}
@@ -1140,6 +1140,7 @@ export default function EventDetailPage() {
                   <span className="material-symbols-rounded text-sm">auto_awesome</span>
                   AI推測
                 </span>
+                <span className="ml-auto text-xs tracking-[0.2em] text-[var(--muted)]">最大5件</span>
               </h2>
               <ul className="mt-4 grid gap-3 text-sm text-[var(--muted)] md:grid-cols-2">
                 {event.timeCandidates.map((candidate) => (
@@ -1203,8 +1204,8 @@ export default function EventDetailPage() {
 
             {needsPlaceCandidates && (
               <div>
-              <h2 className="flex items-center gap-2 text-lg font-semibold">
-                場所
+              <h2 className="flex w-full items-center gap-2 text-lg font-semibold">
+                場所候補
                 <button
                   onClick={openPlaceProposalOverlay}
                   disabled={candidateActionsDisabled || !canAccessParticipantActions}
@@ -1217,6 +1218,7 @@ export default function EventDetailPage() {
                   <span className="material-symbols-rounded text-sm">auto_awesome</span>
                   AI推測
                 </span>
+                <span className="ml-auto text-xs tracking-[0.2em] text-[var(--muted)]">最大5件</span>
               </h2>
               <ul className="mt-4 grid gap-3 text-sm text-[var(--muted)] md:grid-cols-2">
                 {event.placeCandidates.map((candidate) => (
@@ -1380,29 +1382,18 @@ export default function EventDetailPage() {
               <div className="mt-4">
                 <p className="mb-2 text-xs font-semibold text-[var(--muted)]">候補日程</p>
                 <ul className="space-y-2">
-                  {dateSuggestions.map((dateStr) => {
-                    const date = new Date(dateStr);
-                    const weekday = ["日", "月", "火", "水", "木", "金", "土"][date.getDay()];
-                    const month = date.getMonth() + 1;
-                    const day = date.getDate();
-                    return (
-                      <li key={dateStr}>
-                        <button
-                          onClick={() => handleTimeProposal(dateStr)}
-                          className="flex w-full items-center gap-3 rounded-2xl bg-white p-4 text-left shadow-sm hover:bg-orange-50"
-                        >
-                          <div className="flex h-10 w-10 shrink-0 flex-col items-center justify-center rounded-xl bg-orange-50">
-                            <span className="text-[9px] font-semibold text-[var(--accent)]">{month}月</span>
-                            <span className="text-base font-bold leading-none text-[var(--accent)]">{day}</span>
-                          </div>
-                          <div className="min-w-0">
-                            <p className="font-semibold text-[var(--foreground)]">{weekday}曜日</p>
-                            <p className="text-xs text-[var(--muted)]">18:00〜</p>
-                          </div>
-                        </button>
-                      </li>
-                    );
-                  })}
+                  {dateSuggestions.map((dateStr) => (
+                    <li key={dateStr}>
+                      <button
+                        onClick={() => handleTimeProposal(dateStr)}
+                        className="flex w-full items-center gap-3 rounded-2xl bg-white px-4 py-3 text-left shadow-sm hover:bg-orange-50"
+                      >
+                        <p className="min-w-0 flex-1 truncate font-semibold text-[var(--foreground)]">
+                          {formatStart(dateStr)}
+                        </p>
+                      </button>
+                    </li>
+                  ))}
                 </ul>
               </div>
             )}

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -1150,10 +1150,10 @@ export default function EventDetailPage() {
                     {canDeleteCandidate(candidate) && (
                       <button
                         onClick={() => handleDeleteTimeCandidate(candidate.id)}
-                        className="absolute left-0 top-0 z-10 flex h-5 w-5 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full bg-gray-400 text-white hover:bg-rose-500"
+                        className="absolute left-4 top-4 z-10 flex h-5 w-5 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full bg-gray-400 text-white hover:bg-rose-500"
                         aria-label="候補を削除"
                       >
-                        <span className="material-symbols-rounded text-[10px] leading-none">close</span>
+                        <span className="material-symbols-rounded leading-none" style={{ fontSize: "8px" }}>close</span>
                       </button>
                     )}
                     <div className="flex items-center gap-3">
@@ -1227,10 +1227,10 @@ export default function EventDetailPage() {
                     {canDeleteCandidate(candidate) && (
                       <button
                         onClick={() => handleDeletePlaceCandidate(candidate.id)}
-                        className="absolute left-0 top-0 z-10 flex h-5 w-5 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full bg-gray-400 text-white hover:bg-rose-500"
+                        className="absolute left-4 top-4 z-10 flex h-5 w-5 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full bg-gray-400 text-white hover:bg-rose-500"
                         aria-label="候補を削除"
                       >
-                        <span className="material-symbols-rounded text-[10px] leading-none">close</span>
+                        <span className="material-symbols-rounded leading-none" style={{ fontSize: "8px" }}>close</span>
                       </button>
                     )}
                     <div className="flex min-w-0 items-center gap-3">

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -1145,7 +1145,7 @@ export default function EventDetailPage() {
                     {canDeleteCandidate(candidate) && (
                       <button
                         onClick={() => handleDeleteTimeCandidate(candidate.id)}
-                        className="absolute left-2 top-2 z-10 flex h-5 w-5 items-center justify-center rounded-full bg-gray-400 text-white hover:bg-rose-500"
+                        className="absolute left-0 top-0 z-10 flex h-5 w-5 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full bg-gray-400 text-white hover:bg-rose-500"
                         aria-label="候補を削除"
                       >
                         <span className="material-symbols-rounded leading-none" style={{ fontSize: "16px" }}>close</span>
@@ -1222,7 +1222,7 @@ export default function EventDetailPage() {
                     {canDeleteCandidate(candidate) && (
                       <button
                         onClick={() => handleDeletePlaceCandidate(candidate.id)}
-                        className="absolute left-2 top-2 z-10 flex h-5 w-5 items-center justify-center rounded-full bg-gray-400 text-white hover:bg-rose-500"
+                        className="absolute left-0 top-0 z-10 flex h-5 w-5 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full bg-gray-400 text-white hover:bg-rose-500"
                         aria-label="候補を削除"
                       >
                         <span className="material-symbols-rounded leading-none" style={{ fontSize: "16px" }}>close</span>

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -729,6 +729,7 @@ export default function EventDetailPage() {
 
   const handleDeleteTimeCandidate = async (candidateId: string) => {
     if (!userId || !event) return;
+    if (!window.confirm("この日程候補を削除しますか？")) return;
     await fetch(`/api/events/${eventId}/candidates/time/${candidateId}`, {
       method: "DELETE",
       headers: { "Content-Type": "application/json" },
@@ -744,6 +745,7 @@ export default function EventDetailPage() {
 
   const handleDeletePlaceCandidate = async (candidateId: string) => {
     if (!userId || !event) return;
+    if (!window.confirm("この場所候補を削除しますか？")) return;
     await fetch(`/api/events/${eventId}/candidates/place/${candidateId}`, {
       method: "DELETE",
       headers: { "Content-Type": "application/json" },

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -1138,7 +1138,7 @@ export default function EventDetailPage() {
                 </button>
                 <span className="inline-flex items-center gap-1 rounded-full bg-sky-100 px-2 py-1 text-[10px] font-semibold tracking-[0.08em] text-sky-700">
                   <span className="material-symbols-rounded text-sm">auto_awesome</span>
-                  最大5件・日付順
+                  AI推測
                 </span>
               </h2>
               <ul className="mt-4 grid gap-3 text-sm text-[var(--muted)] md:grid-cols-2">
@@ -1215,7 +1215,7 @@ export default function EventDetailPage() {
                 </button>
                 <span className="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-1 text-[10px] font-semibold tracking-[0.08em] text-amber-700">
                   <span className="material-symbols-rounded text-sm">auto_awesome</span>
-                  候補 最大5件
+                  AI推測
                 </span>
               </h2>
               <ul className="mt-4 grid gap-3 text-sm text-[var(--muted)] md:grid-cols-2">

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -456,7 +456,7 @@ export default function EventDetailPage() {
   const fetchPlaceSuggestions = async (category = "") => {
     if (!event) return;
     setIsSuggestionsLoading(true);
-    const baseQuery = event.area ?? event.purpose ?? "東京";
+    const baseQuery = [event.area, event.purpose].filter(Boolean).join(" ") || "東京";
     const query = [baseQuery, category].filter(Boolean).join(" ");
     const response = await fetch(
       `/api/places/search?query=${encodeURIComponent(query)}&limit=5`
@@ -1411,29 +1411,22 @@ export default function EventDetailPage() {
               ) : suggestedPlaces.length > 0 ? (
                 <ul className="space-y-2 text-sm">
                   {suggestedPlaces.map((place) => (
-                    <li
-                      key={place.placeId}
-                      className="flex flex-col gap-2 rounded-2xl bg-white px-3 py-2 shadow-sm sm:flex-row sm:items-center sm:justify-between"
-                    >
-                      <div className="min-w-0 flex items-center gap-2">
+                    <li key={place.placeId}>
+                      <button
+                        onClick={() => handlePlaceProposal(place)}
+                        className="flex w-full items-center gap-2 rounded-2xl bg-white px-3 py-2 text-left shadow-sm hover:bg-orange-50"
+                      >
                         <Image
                           src={place.photoUrl ?? "/file.svg"}
                           alt={`${place.name} の写真`}
                           width={40}
                           height={40}
-                          className="h-10 w-10 rounded-xl object-cover"
+                          className="h-10 w-10 shrink-0 rounded-xl object-cover"
                         />
                         <div className="min-w-0">
                           <p className="truncate text-sm font-semibold text-[var(--foreground)]">{place.name}</p>
                           <p className="truncate text-xs text-[var(--muted)]">{place.address}</p>
                         </div>
-                      </div>
-                      <button
-                        onClick={() => handlePlaceProposal(place)}
-                        className="flex w-full items-center justify-center gap-1 rounded-full bg-orange-100 px-3 py-1 text-xs font-semibold text-[var(--accent)] sm:w-auto"
-                      >
-                        <span className="material-symbols-rounded">add</span>
-                        追加
                       </button>
                     </li>
                   ))}
@@ -1469,29 +1462,22 @@ export default function EventDetailPage() {
               {placeResults.length > 0 && (
                 <ul className="max-h-48 space-y-2 overflow-y-auto pr-1 text-sm">
                   {placeResults.map((place) => (
-                    <li
-                      key={place.placeId}
-                      className="flex flex-col gap-2 rounded-2xl bg-white px-3 py-2 shadow-sm sm:flex-row sm:items-center sm:justify-between"
-                    >
-                      <div className="min-w-0 flex items-center gap-2">
+                    <li key={place.placeId}>
+                      <button
+                        onClick={() => handlePlaceProposal(place)}
+                        className="flex w-full items-center gap-2 rounded-2xl bg-white px-3 py-2 text-left shadow-sm hover:bg-orange-50"
+                      >
                         <Image
                           src={place.photoUrl ?? "/file.svg"}
                           alt={`${place.name} の写真`}
                           width={40}
                           height={40}
-                          className="h-10 w-10 rounded-xl object-cover"
+                          className="h-10 w-10 shrink-0 rounded-xl object-cover"
                         />
                         <div className="min-w-0">
                           <p className="truncate text-sm font-semibold text-[var(--foreground)]">{place.name}</p>
                           <p className="truncate text-xs text-[var(--muted)]">{place.address}</p>
                         </div>
-                      </div>
-                      <button
-                        onClick={() => handlePlaceProposal(place)}
-                        className="flex w-full items-center justify-center gap-1 rounded-full bg-orange-100 px-3 py-1 text-xs font-semibold text-[var(--accent)] sm:w-auto"
-                      >
-                        <span className="material-symbols-rounded">add</span>
-                        追加
                       </button>
                     </li>
                   ))}

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -1150,10 +1150,10 @@ export default function EventDetailPage() {
                     {canDeleteCandidate(candidate) && (
                       <button
                         onClick={() => handleDeleteTimeCandidate(candidate.id)}
-                        className="absolute left-2 top-2 grid h-5 w-5 place-items-center rounded-full bg-gray-100 text-gray-400 hover:bg-rose-100 hover:text-rose-500"
+                        className="absolute -left-2.5 -top-2.5 z-10 flex h-5 w-5 items-center justify-center rounded-full bg-gray-100 text-gray-400 hover:bg-rose-100 hover:text-rose-500"
                         aria-label="候補を削除"
                       >
-                        <span className="material-symbols-rounded text-xs">close</span>
+                        <span className="material-symbols-rounded text-[12px] leading-none">close</span>
                       </button>
                     )}
                     <div className="flex items-center gap-3">
@@ -1223,14 +1223,14 @@ export default function EventDetailPage() {
               </h2>
               <ul className="mt-4 grid gap-3 text-sm text-[var(--muted)] md:grid-cols-2">
                 {event.placeCandidates.map((candidate) => (
-                  <li key={candidate.id} className="relative overflow-hidden rounded-2xl bg-white p-4 shadow-sm">
+                  <li key={candidate.id} className="relative rounded-2xl bg-white p-4 shadow-sm">
                     {canDeleteCandidate(candidate) && (
                       <button
                         onClick={() => handleDeletePlaceCandidate(candidate.id)}
-                        className="absolute left-2 top-2 grid h-5 w-5 place-items-center rounded-full bg-gray-100 text-gray-400 hover:bg-rose-100 hover:text-rose-500"
+                        className="absolute -left-2.5 -top-2.5 z-10 flex h-5 w-5 items-center justify-center rounded-full bg-gray-100 text-gray-400 hover:bg-rose-100 hover:text-rose-500"
                         aria-label="候補を削除"
                       >
-                        <span className="material-symbols-rounded text-xs">close</span>
+                        <span className="material-symbols-rounded text-[12px] leading-none">close</span>
                       </button>
                     )}
                     <div className="flex min-w-0 items-center gap-3">

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -443,6 +443,10 @@ export default function EventDetailPage() {
       setInviteMessage(participantActionNotice);
       return;
     }
+    if ((event?.timeCandidates.length ?? 0) >= 5) {
+      window.alert("日程候補は最大5件までです。既存の候補を削除してから追加してください。");
+      return;
+    }
     const existing = event?.timeCandidates.map((c) => c.startTime) ?? [];
     setDateSuggestions(generateWeekendSuggestions(existing));
     setShowTimeOverlay(true);
@@ -471,6 +475,10 @@ export default function EventDetailPage() {
     }
     if (!canAccessParticipantActions) {
       setInviteMessage(participantActionNotice);
+      return;
+    }
+    if ((event?.placeCandidates.length ?? 0) >= 5) {
+      window.alert("場所候補は最大5件までです。既存の候補を削除してから追加してください。");
       return;
     }
     setPlaceCategory("");
@@ -965,7 +973,7 @@ export default function EventDetailPage() {
                 日程
               </p>
               <p className="mt-2 text-sm font-semibold">
-                {formatStart(event.fixedStartTime)}
+                {event.fixedStartTime ? formatStart(event.fixedStartTime) : "候補から決定"}
               </p>
             </div>
             <div className="p-1">

--- a/lib/places.ts
+++ b/lib/places.ts
@@ -209,7 +209,7 @@ const fetchPlacesWithNewApi = async (
   }
 
   const payload = (await response.json()) as GooglePlaceNewSearchResponse;
-  return mapPlacesNew(payload.places ?? [], apiKey).slice(0, 6);
+  return mapPlacesNew(payload.places ?? [], apiKey).slice(0, 10);
 };
 
 const fetchPlacesWithLegacyApi = async (
@@ -229,7 +229,7 @@ const fetchPlacesWithLegacyApi = async (
     results?: GooglePlaceSearchItem[];
   };
 
-  return mapPlaces(payload.results ?? []).slice(0, 6);
+  return mapPlaces(payload.results ?? []).slice(0, 10);
 };
 
 export async function getPlacesForQuery(


### PR DESCRIPTION
## 概要
Issue #54 の対応。場所・日程の追加フローで「＋」ボタンを押した際に、候補一覧がオーバーレイにあらかじめ表示される仕様に変更し、UXを改善した。

**関連ドキュメント**
- [Issue #54](https://github.com/Meet-develop/meet-moc/issues/54)

## 影響範囲
- DBマイグレーションなし
- 日程候補・場所候補の削除APIを新規追加（既存APIへの破壊的変更なし）
- `app/events/[id]/page.tsx`（イベント詳細画面）のUI変更のみ、他画面への影響なし

## 変更点

**AS IS**
- 日程追加: datetime-local の手入力のみ
- 場所追加: テキスト検索を実行して初めて結果が表示される
- 追加済み候補の削除機能なし
- 日程候補の表示は最大3件・スコア降順

**TO BE**
- 日程追加: 「＋」タップ時に翌日以降の土日5件をカード形式で即表示。手入力も引き続き利用可能
- 場所追加: 「＋」タップ時に `event.area × event.purpose` クエリで5件を自動取得して即表示。カテゴリーフィルター（居酒屋・カフェ・レストラン・バー・焼肉）で絞り込みも可能。手動検索も残存
- 候補カードの左上に「×」ボタンを追加。オーナーは全件削除可、提案者は自分の候補のみ削除可。削除前に確認ダイアログを表示
- 日程候補を最大5件・日付昇順で表示
- すでに5件の候補がある場合は「＋」ボタンを押した時点でアラートを表示し、オーバーレイを開かない
- 日程が未確定の場合の表示を「未確定」→「候補から決定」に変更（場所と表記統一）
- 見出しに「最大5件」バッジを追加

## QA 観点
- 候補削除APIはオーナー権限・提案者権限・イベントステータス（open のみ）を確認してから削除する設計。不正削除が発生しないこと
- 場所オーバーレイで既に追加済みの場所はフィルタリングして表示しないため、重複追加が起こらないこと
- 5件上限チェックはUIレベルで行っているが、API側では件数制限を設けていないため、APIを直接叩けば超えられる点に注意

## 動作確認ケース
- [ ] 日程「＋」ボタンをタップ → 土日5件がカード形式で表示される
- [ ] 日程カードをタップすると即追加されオーバーレイが閉じる
- [ ] datetime-local 手入力からの追加も正常動作
- [ ] 場所「＋」ボタンをタップ → おすすめ5件がローディング後に表示される
- [ ] カテゴリーフィルターをタップすると絞り込み結果に切り替わる
- [ ] 既に追加済みの場所はオーバーレイに表示されない
- [ ] 候補が5件の状態で「＋」を押すとアラートが表示される
- [ ] オーナーは全候補の「×」で削除できる
- [ ] 提案者は自分の候補のみ「×」で削除できる（他人のカードには「×」が表示されない）
- [ ] 削除前に確認ダイアログが表示される
- [ ] 手動検索（「他の場所を探す」）も正常動作
- [ ] 既存の投票機能にリグレッションなし

## レビュアーに特に見て欲しいポイント
- 候補削除API（`app/api/events/[id]/candidates/time/[candidateId]/route.ts` / `place/[candidateId]/route.ts`）の認可ロジック