### PR TITLE
[FEAT] イベント作成の日程設定を3種類に拡張し詳細設定から独立させる

### DIFF
--- a/app/api/events/[id]/route.ts
+++ b/app/api/events/[id]/route.ts
@@ -267,7 +267,7 @@ export async function PATCH(
     eventArea?: string;
     visibility?: "public" | "limited" | "private";
     capacity?: number;
-    timeSetting?: "auto" | "manual";
+    timeSetting?: "auto" | "candidates" | "manual";
     placeSetting?: "auto" | "manual";
     fixedStartTime?: string;
     fixedPlace?: {
@@ -276,6 +276,10 @@ export async function PATCH(
       address?: string;
     } | null;
     placeQuery?: string;
+    userTimeCandidates?: {
+      startTime: string;
+      endTime: string;
+    }[];
     candidatePlaces?: {
       placeId: string;
       name: string;
@@ -322,7 +326,9 @@ export async function PATCH(
   } = {};
 
   const hasTimeSetting =
-    body.timeSetting === "auto" || body.timeSetting === "manual";
+    body.timeSetting === "auto" ||
+    body.timeSetting === "candidates" ||
+    body.timeSetting === "manual";
   const hasPlaceSetting =
     body.placeSetting === "auto" || body.placeSetting === "manual";
   const hasFixedPlacePayload = body.fixedPlace !== undefined;
@@ -395,7 +401,7 @@ export async function PATCH(
     updateData.fixedEndTime = new Date(
       fixedStartTime.getTime() + 2 * 60 * 60 * 1000
     );
-  } else if (hasTimeSetting && body.timeSetting === "auto") {
+  } else if (hasTimeSetting && (body.timeSetting === "auto" || body.timeSetting === "candidates")) {
     updateData.fixedStartTime = null;
     updateData.fixedEndTime = null;
   }
@@ -404,12 +410,18 @@ export async function PATCH(
     updateData.scheduleMode = derivedScheduleMode;
   }
 
+  const isTimeCandidatesMode = body.timeSetting === "candidates";
   const shouldRegenerateTimeCandidates =
     nextTimeSetting === "auto" &&
     (currentTimeSetting === "manual" || event.timeCandidates.length === 0);
+  const shouldReplaceWithUserCandidates =
+    isTimeCandidatesMode &&
+    body.userTimeCandidates != null &&
+    body.userTimeCandidates.length > 0;
   const shouldDeleteTimeCandidates =
     (hasTimeSetting && body.timeSetting === "manual") ||
-    shouldRegenerateTimeCandidates;
+    shouldRegenerateTimeCandidates ||
+    shouldReplaceWithUserCandidates;
 
   const shouldRegeneratePlaceCandidates =
     nextPlaceSetting === "auto" &&
@@ -516,7 +528,17 @@ export async function PATCH(
     });
   }
 
-  if (shouldRegenerateTimeCandidates) {
+  if (shouldReplaceWithUserCandidates && body.userTimeCandidates) {
+    await prisma.eventTimeCandidate.createMany({
+      data: body.userTimeCandidates.slice(0, 10).map((c) => ({
+        eventId: id,
+        startTime: new Date(c.startTime),
+        endTime: new Date(c.endTime),
+        score: 0,
+        source: "system",
+      })),
+    });
+  } else if (shouldRegenerateTimeCandidates) {
     type ParticipantAvailabilitySource = { userId: string; status: string };
     type ProfileAvailabilitySource = { availability: unknown };
 

--- a/app/api/events/[id]/route.ts
+++ b/app/api/events/[id]/route.ts
@@ -294,6 +294,16 @@ export async function PATCH(
     return NextResponse.json({ message: "Missing ownerId" }, { status: 400 });
   }
 
+  if (
+    body.timeSetting === "candidates" &&
+    (!body.userTimeCandidates || body.userTimeCandidates.length === 0)
+  ) {
+    return NextResponse.json(
+      { message: "userTimeCandidates must not be empty when timeSetting is candidates" },
+      { status: 400 }
+    );
+  }
+
   const event = await prisma.event.findUnique({
     where: { id },
     include: {
@@ -522,23 +532,24 @@ export async function PATCH(
     });
   }
 
-  if (shouldDeleteTimeCandidates) {
-    await prisma.eventTimeCandidate.deleteMany({
-      where: { eventId: id },
+  if (shouldDeleteTimeCandidates && shouldReplaceWithUserCandidates && body.userTimeCandidates) {
+    const parsedCandidates = body.userTimeCandidates.slice(0, 10).map((c) => {
+      const start = new Date(c.startTime);
+      const end = new Date(c.endTime);
+      if (isNaN(start.getTime()) || isNaN(end.getTime())) {
+        throw new Error(`Invalid date in userTimeCandidates: ${JSON.stringify(c)}`);
+      }
+      return { eventId: id, startTime: start, endTime: end, score: 0, source: "system" as const };
     });
+    await prisma.$transaction([
+      prisma.eventTimeCandidate.deleteMany({ where: { eventId: id } }),
+      prisma.eventTimeCandidate.createMany({ data: parsedCandidates }),
+    ]);
+  } else if (shouldDeleteTimeCandidates) {
+    await prisma.eventTimeCandidate.deleteMany({ where: { eventId: id } });
   }
 
-  if (shouldReplaceWithUserCandidates && body.userTimeCandidates) {
-    await prisma.eventTimeCandidate.createMany({
-      data: body.userTimeCandidates.slice(0, 10).map((c) => ({
-        eventId: id,
-        startTime: new Date(c.startTime),
-        endTime: new Date(c.endTime),
-        score: 0,
-        source: "system",
-      })),
-    });
-  } else if (shouldRegenerateTimeCandidates) {
+  if (shouldRegenerateTimeCandidates) {
     type ParticipantAvailabilitySource = { userId: string; status: string };
     type ProfileAvailabilitySource = { availability: unknown };
 

--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -319,7 +319,7 @@ export async function POST(request: Request) {
     visibility?: "public" | "limited" | "private";
     capacity?: number;
     scheduleMode?: "fixed" | "candidate";
-    timeSetting?: "auto" | "manual";
+    timeSetting?: "auto" | "candidates" | "manual";
     placeSetting?: "auto" | "manual";
     fixedStartTime?: string;
     fixedPlace?: {
@@ -328,6 +328,10 @@ export async function POST(request: Request) {
       address: string;
     };
     placeQuery?: string;
+    userTimeCandidates?: {
+      startTime: string;
+      endTime: string;
+    }[];
     candidatePlaces?: {
       placeId: string;
       name: string;
@@ -350,6 +354,7 @@ export async function POST(request: Request) {
   const isTimeManual = body.timeSetting
     ? body.timeSetting === "manual"
     : legacyFixed;
+  const isTimeCandidates = body.timeSetting === "candidates";
   const isPlaceManual = body.placeSetting
     ? body.placeSetting === "manual"
     : legacyFixed;
@@ -502,36 +507,48 @@ export async function POST(request: Request) {
 
   if (resolvedScheduleMode === "candidate") {
     if (!isTimeManual) {
-      let inviteeAvailabilities: unknown[] = [];
-      if (inviteeIds.length > 0) {
-        const inviteeProfiles = await prisma.profile.findMany({
-          where: {
-            userId: {
-              in: inviteeIds,
-            },
-          },
-          select: {
-            availability: true,
-          },
+      if (isTimeCandidates && body.userTimeCandidates && body.userTimeCandidates.length > 0) {
+        await prisma.eventTimeCandidate.createMany({
+          data: body.userTimeCandidates.slice(0, 10).map((c) => ({
+            eventId: event.id,
+            startTime: new Date(c.startTime),
+            endTime: new Date(c.endTime),
+            score: 0,
+            source: "system",
+          })),
         });
-        inviteeAvailabilities = inviteeProfiles.map((profile) => profile.availability);
+      } else if (!isTimeCandidates) {
+        let inviteeAvailabilities: unknown[] = [];
+        if (inviteeIds.length > 0) {
+          const inviteeProfiles = await prisma.profile.findMany({
+            where: {
+              userId: {
+                in: inviteeIds,
+              },
+            },
+            select: {
+              availability: true,
+            },
+          });
+          inviteeAvailabilities = inviteeProfiles.map((profile) => profile.availability);
+        }
+
+        const dayPriorityByWeekday = buildDayPriorityByWeekday([
+          ownerProfile?.availability,
+          ...inviteeAvailabilities,
+        ]);
+
+        const timeCandidates = buildDefaultTimeCandidates(
+          ownerProfile?.availability as AvailabilityInput | undefined,
+          dayPriorityByWeekday
+        );
+        await prisma.eventTimeCandidate.createMany({
+          data: timeCandidates.map((candidate: any) => ({
+            eventId: event.id,
+            ...candidate,
+          })),
+        });
       }
-
-      const dayPriorityByWeekday = buildDayPriorityByWeekday([
-        ownerProfile?.availability,
-        ...inviteeAvailabilities,
-      ]);
-
-      const timeCandidates = buildDefaultTimeCandidates(
-        ownerProfile?.availability as AvailabilityInput | undefined,
-        dayPriorityByWeekday
-      );
-      await prisma.eventTimeCandidate.createMany({
-        data: timeCandidates.map((candidate: any) => ({
-          eventId: event.id,
-          ...candidate,
-        })),
-      });
     }
 
     if (!isPlaceManual) {

--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -368,6 +368,13 @@ export async function POST(request: Request) {
     );
   }
 
+  if (isTimeCandidates && (!body.userTimeCandidates || body.userTimeCandidates.length === 0)) {
+    return NextResponse.json(
+      { message: "userTimeCandidates must not be empty when timeSetting is candidates" },
+      { status: 400 }
+    );
+  }
+
   if (isPlaceManual && !body.fixedPlace) {
     return NextResponse.json(
       { message: "fixedPlace is required when placeSetting is manual" },
@@ -508,15 +515,15 @@ export async function POST(request: Request) {
   if (resolvedScheduleMode === "candidate") {
     if (!isTimeManual) {
       if (isTimeCandidates && body.userTimeCandidates && body.userTimeCandidates.length > 0) {
-        await prisma.eventTimeCandidate.createMany({
-          data: body.userTimeCandidates.slice(0, 10).map((c) => ({
-            eventId: event.id,
-            startTime: new Date(c.startTime),
-            endTime: new Date(c.endTime),
-            score: 0,
-            source: "system",
-          })),
+        const parsedCandidates = body.userTimeCandidates.slice(0, 10).map((c) => {
+          const start = new Date(c.startTime);
+          const end = new Date(c.endTime);
+          if (isNaN(start.getTime()) || isNaN(end.getTime())) {
+            throw new Error(`Invalid date in userTimeCandidates: ${JSON.stringify(c)}`);
+          }
+          return { eventId: event.id, startTime: start, endTime: end, score: 0, source: "system" as const };
         });
+        await prisma.eventTimeCandidate.createMany({ data: parsedCandidates });
       } else if (!isTimeCandidates) {
         let inviteeAvailabilities: unknown[] = [];
         if (inviteeIds.length > 0) {

--- a/app/api/profiles/[id]/time-suggestions/route.ts
+++ b/app/api/profiles/[id]/time-suggestions/route.ts
@@ -5,6 +5,10 @@ import {
   type AvailabilityInput,
 } from "@/lib/event-time-candidates";
 
+const TWO_WEEKS = 14;
+const DEFAULT_COUNT = 3;
+const SUGGESTION_COUNT = 5;
+
 export async function GET(
   _request: Request,
   { params }: { params: Promise<{ id: string }> }
@@ -20,14 +24,33 @@ export async function GET(
     return NextResponse.json({ message: "Not found" }, { status: 404 });
   }
 
-  const candidates = buildDefaultTimeCandidates(
-    profile.availability as AvailabilityInput | undefined
+  const availability = profile.availability as AvailabilityInput | undefined;
+
+  const defaults = buildDefaultTimeCandidates(
+    availability,
+    undefined,
+    new Date(),
+    TWO_WEEKS,
+    DEFAULT_COUNT
   );
 
+  const defaultStartTimes = new Set(defaults.map((c) => c.startTime.getTime()));
+
+  const suggestionPool = buildDefaultTimeCandidates(
+    availability,
+    undefined,
+    new Date(),
+    TWO_WEEKS,
+    DEFAULT_COUNT + SUGGESTION_COUNT
+  ).filter((c) => !defaultStartTimes.has(c.startTime.getTime()));
+
+  const toEntry = (c: { startTime: Date; endTime: Date }) => ({
+    startTime: c.startTime.toISOString(),
+    endTime: c.endTime.toISOString(),
+  });
+
   return NextResponse.json({
-    candidates: candidates.map((c) => ({
-      startTime: c.startTime.toISOString(),
-      endTime: c.endTime.toISOString(),
-    })),
+    defaults: defaults.map(toEntry),
+    suggestions: suggestionPool.map(toEntry),
   });
 }

--- a/app/api/profiles/[id]/time-suggestions/route.ts
+++ b/app/api/profiles/[id]/time-suggestions/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import {
+  buildDefaultTimeCandidates,
+  type AvailabilityInput,
+} from "@/lib/event-time-candidates";
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  const profile = await prisma.profile.findUnique({
+    where: { userId: id },
+    select: { availability: true },
+  });
+
+  if (!profile) {
+    return NextResponse.json({ message: "Not found" }, { status: 404 });
+  }
+
+  const candidates = buildDefaultTimeCandidates(
+    profile.availability as AvailabilityInput | undefined
+  );
+
+  return NextResponse.json({
+    candidates: candidates.map((c) => ({
+      startTime: c.startTime.toISOString(),
+      endTime: c.endTime.toISOString(),
+    })),
+  });
+}

--- a/app/api/profiles/[id]/time-suggestions/route.ts
+++ b/app/api/profiles/[id]/time-suggestions/route.ts
@@ -8,6 +8,7 @@ import {
 const TWO_WEEKS = 14;
 const DEFAULT_COUNT = 3;
 const SUGGESTION_COUNT = 5;
+const WINDOW_DAYS = 56;
 
 export async function GET(
   _request: Request,
@@ -26,23 +27,17 @@ export async function GET(
 
   const availability = profile.availability as AvailabilityInput | undefined;
 
-  const defaults = buildDefaultTimeCandidates(
+  const allCandidates = buildDefaultTimeCandidates(
     availability,
     undefined,
     new Date(),
     TWO_WEEKS,
-    DEFAULT_COUNT
+    DEFAULT_COUNT + SUGGESTION_COUNT,
+    WINDOW_DAYS
   );
 
-  const defaultStartTimes = new Set(defaults.map((c) => c.startTime.getTime()));
-
-  const suggestionPool = buildDefaultTimeCandidates(
-    availability,
-    undefined,
-    new Date(),
-    TWO_WEEKS,
-    DEFAULT_COUNT + SUGGESTION_COUNT
-  ).filter((c) => !defaultStartTimes.has(c.startTime.getTime()));
+  const defaults = allCandidates.slice(0, DEFAULT_COUNT);
+  const suggestions = allCandidates.slice(DEFAULT_COUNT);
 
   const toEntry = (c: { startTime: Date; endTime: Date }) => ({
     startTime: c.startTime.toISOString(),
@@ -51,6 +46,6 @@ export async function GET(
 
   return NextResponse.json({
     defaults: defaults.map(toEntry),
-    suggestions: suggestionPool.map(toEntry),
+    suggestions: suggestions.map(toEntry),
   });
 }

--- a/app/api/profiles/[id]/time-suggestions/route.ts
+++ b/app/api/profiles/[id]/time-suggestions/route.ts
@@ -14,38 +14,46 @@ export async function GET(
   _request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const { id } = await params;
+  try {
+    const { id } = await params;
 
-  const profile = await prisma.profile.findUnique({
-    where: { userId: id },
-    select: { availability: true },
-  });
+    const profile = await prisma.profile.findUnique({
+      where: { userId: id },
+      select: { availability: true },
+    });
 
-  if (!profile) {
-    return NextResponse.json({ message: "Not found" }, { status: 404 });
+    if (!profile) {
+      return NextResponse.json({ message: "Not found" }, { status: 404 });
+    }
+
+    const availability = profile.availability as AvailabilityInput | undefined;
+
+    const allCandidates = buildDefaultTimeCandidates(
+      availability,
+      undefined,
+      new Date(),
+      TWO_WEEKS,
+      DEFAULT_COUNT + SUGGESTION_COUNT,
+      WINDOW_DAYS
+    );
+
+    const defaults = allCandidates.slice(0, DEFAULT_COUNT);
+    const suggestions = allCandidates.slice(DEFAULT_COUNT);
+
+    const toEntry = (c: { startTime: Date; endTime: Date }) => ({
+      startTime: c.startTime.toISOString(),
+      endTime: c.endTime.toISOString(),
+    });
+
+    return NextResponse.json({
+      defaults: defaults.map(toEntry),
+      suggestions: suggestions.map(toEntry),
+    });
+  } catch (error) {
+    console.error("[time-suggestions] unexpected error:", error);
+    return NextResponse.json(
+      { message: "Internal server error" },
+      { status: 500 }
+    );
   }
-
-  const availability = profile.availability as AvailabilityInput | undefined;
-
-  const allCandidates = buildDefaultTimeCandidates(
-    availability,
-    undefined,
-    new Date(),
-    TWO_WEEKS,
-    DEFAULT_COUNT + SUGGESTION_COUNT,
-    WINDOW_DAYS
-  );
-
-  const defaults = allCandidates.slice(0, DEFAULT_COUNT);
-  const suggestions = allCandidates.slice(DEFAULT_COUNT);
-
-  const toEntry = (c: { startTime: Date; endTime: Date }) => ({
-    startTime: c.startTime.toISOString(),
-    endTime: c.endTime.toISOString(),
-  });
-
-  return NextResponse.json({
-    defaults: defaults.map(toEntry),
-    suggestions: suggestions.map(toEntry),
-  });
 }

--- a/app/events/new/page.tsx
+++ b/app/events/new/page.tsx
@@ -67,14 +67,7 @@ type EventUpdateComparable = {
   } | null;
 };
 
-type SuggestedCandidate = {
-  id: string;
-  startTime: string;
-  endTime: string;
-  selected: boolean;
-};
-
-type ManualCandidate = {
+type TimeCandidate = {
   id: string;
   startTime: string;
   endTime: string;
@@ -134,14 +127,14 @@ const plusButtonClass =
 const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
 const WEEKDAY_LABELS = ["日", "月", "火", "水", "木", "金", "土"] as const;
 
-const formatCandidateTime = (isoString: string) => {
+const formatCandidateStart = (isoString: string) => {
   const jst = new Date(new Date(isoString).getTime() + JST_OFFSET_MS);
   const month = jst.getUTCMonth() + 1;
   const day = jst.getUTCDate();
   const weekday = WEEKDAY_LABELS[jst.getUTCDay()];
   const h = String(jst.getUTCHours()).padStart(2, "0");
   const m = String(jst.getUTCMinutes()).padStart(2, "0");
-  return `${month}月${day}日 (${weekday}) ${h}:${m}`;
+  return `${month}月${day}日 (${weekday}) ${h}:${m}〜`;
 };
 
 const generateId = () => Math.random().toString(36).slice(2);
@@ -254,9 +247,9 @@ function EventCreatePageContent() {
   const [timeSetting, setTimeSetting] = useState<"auto" | "candidates" | "manual">("auto");
   const [placeSetting, setPlaceSetting] = useState<"auto" | "manual">("auto");
   const [fixedStart, setFixedStart] = useState("");
-  const [suggestedCandidates, setSuggestedCandidates] = useState<SuggestedCandidate[]>([]);
+  const [activeCandidates, setActiveCandidates] = useState<TimeCandidate[]>([]);
+  const [suggestionPool, setSuggestionPool] = useState<TimeCandidate[]>([]);
   const [isSuggestionsLoading, setIsSuggestionsLoading] = useState(false);
-  const [manualTimeCandidates, setManualTimeCandidates] = useState<ManualCandidate[]>([]);
   const [manualDateInput, setManualDateInput] = useState("");
   const [showManualDateInput, setShowManualDateInput] = useState(false);
   const [selectedPlace, setSelectedPlace] = useState<PlaceResult | null>(null);
@@ -410,7 +403,8 @@ function EventCreatePageContent() {
 
   useEffect(() => {
     if (timeSetting !== "candidates" || !userId) {
-      setSuggestedCandidates([]);
+      setActiveCandidates([]);
+      setSuggestionPool([]);
       return;
     }
 
@@ -425,15 +419,14 @@ function EventCreatePageContent() {
       if (!active) return;
       if (response.ok) {
         const data = (await response.json()) as {
-          candidates: { startTime: string; endTime: string }[];
+          defaults: { startTime: string; endTime: string }[];
+          suggestions: { startTime: string; endTime: string }[];
         };
-        setSuggestedCandidates(
-          data.candidates.map((c) => ({
-            id: generateId(),
-            startTime: c.startTime,
-            endTime: c.endTime,
-            selected: true,
-          }))
+        setActiveCandidates(
+          data.defaults.map((c) => ({ id: generateId(), startTime: c.startTime, endTime: c.endTime }))
+        );
+        setSuggestionPool(
+          data.suggestions.map((c) => ({ id: generateId(), startTime: c.startTime, endTime: c.endTime }))
         );
       }
       setIsSuggestionsLoading(false);
@@ -488,13 +481,8 @@ function EventCreatePageContent() {
   }, [autoTitle, eventTitleInput, isTitleCustomized]);
 
   const allUserTimeCandidates = useMemo(
-    () => [
-      ...suggestedCandidates
-        .filter((c) => c.selected)
-        .map((c) => ({ startTime: c.startTime, endTime: c.endTime })),
-      ...manualTimeCandidates.map((c) => ({ startTime: c.startTime, endTime: c.endTime })),
-    ],
-    [suggestedCandidates, manualTimeCandidates]
+    () => activeCandidates.map((c) => ({ startTime: c.startTime, endTime: c.endTime })),
+    [activeCandidates]
   );
 
   const isTimeManualValid =
@@ -1323,68 +1311,29 @@ function EventCreatePageContent() {
                 </div>
 
                 {timeSetting === "candidates" && (
-                  <div className="mt-4">
-                    <p className="mb-2 text-xs font-semibold text-[var(--foreground)]">
-                      提案候補（プロフィールの空き日程から）
-                    </p>
-                    {isSuggestionsLoading ? (
-                      <p className="text-xs text-[var(--muted)]">候補を取得中...</p>
-                    ) : suggestedCandidates.length === 0 ? (
-                      <p className="text-xs text-[var(--muted)]">
-                        プロフィールに空き日程が設定されていません。下の手動追加から日程を入力してください。
-                      </p>
-                    ) : (
-                      <div className="space-y-2">
-                        {suggestedCandidates.map((candidate) => (
-                          <button
-                            key={candidate.id}
-                            onClick={() =>
-                              setSuggestedCandidates((prev) =>
-                                prev.map((c) =>
-                                  c.id === candidate.id ? { ...c, selected: !c.selected } : c
-                                )
-                              )
-                            }
-                            className={`flex w-full items-center gap-3 rounded-2xl px-4 py-3 text-left ${
-                              candidate.selected ? "bg-orange-50 shadow-md" : "bg-white shadow-sm"
-                            }`}
-                          >
-                            <span
-                              className={`grid h-5 w-5 flex-shrink-0 place-items-center rounded-full border ${
-                                candidate.selected
-                                  ? "border-[var(--accent)] bg-[var(--accent)] text-white"
-                                  : "border-gray-300 bg-white"
-                              }`}
-                            >
-                              {candidate.selected && (
-                                <span className="material-symbols-rounded text-xs">check</span>
-                              )}
-                            </span>
-                            <span className="text-sm">
-                              {formatCandidateTime(candidate.startTime)}〜{formatCandidateTime(candidate.endTime).split(" ").pop()}
-                            </span>
-                          </button>
-                        ))}
-                      </div>
-                    )}
-
-                    {manualTimeCandidates.length > 0 && (
-                      <div className="mt-3">
-                        <p className="mb-2 text-xs font-semibold text-[var(--foreground)]">手動追加した候補</p>
+                  <div className="mt-4 space-y-4">
+                    {/* 日程候補 */}
+                    <div>
+                      <p className="mb-2 text-xs font-semibold text-[var(--foreground)]">日程候補</p>
+                      {isSuggestionsLoading ? (
+                        <p className="text-xs text-[var(--muted)]">候補を取得中...</p>
+                      ) : activeCandidates.length === 0 ? (
+                        <p className="text-xs text-[var(--muted)]">
+                          候補がありません。下の「提案候補」から選択するか、日程を手動追加してください。
+                        </p>
+                      ) : (
                         <div className="space-y-2">
-                          {manualTimeCandidates.map((candidate) => (
+                          {activeCandidates.map((candidate) => (
                             <div
                               key={candidate.id}
                               className="flex items-center justify-between rounded-2xl bg-orange-50 px-4 py-3 shadow-sm"
                             >
-                              <span className="text-sm">{formatCandidateTime(candidate.startTime)}</span>
+                              <span className="text-sm">{formatCandidateStart(candidate.startTime)}</span>
                               <button
                                 onClick={() =>
-                                  setManualTimeCandidates((prev) =>
-                                    prev.filter((c) => c.id !== candidate.id)
-                                  )
+                                  setActiveCandidates((prev) => prev.filter((c) => c.id !== candidate.id))
                                 }
-                                className="grid h-6 w-6 place-items-center rounded-full bg-white text-[var(--muted)] shadow-sm"
+                                className="grid h-6 w-6 flex-shrink-0 place-items-center rounded-full bg-white text-[var(--muted)] shadow-sm"
                                 aria-label="削除"
                               >
                                 <span className="material-symbols-rounded text-sm">close</span>
@@ -1392,10 +1341,38 @@ function EventCreatePageContent() {
                             </div>
                           ))}
                         </div>
+                      )}
+                      {activeCandidates.length === 0 && !isSuggestionsLoading && (
+                        <p className="mt-1 text-xs text-rose-500">
+                          候補を1件以上追加してください。
+                        </p>
+                      )}
+                    </div>
+
+                    {/* 提案候補 */}
+                    {!isSuggestionsLoading && suggestionPool.length > 0 && (
+                      <div>
+                        <p className="mb-2 text-xs font-semibold text-[var(--foreground)]">提案候補</p>
+                        <div className="space-y-2">
+                          {suggestionPool.map((candidate) => (
+                            <button
+                              key={candidate.id}
+                              onClick={() => {
+                                setSuggestionPool((prev) => prev.filter((c) => c.id !== candidate.id));
+                                setActiveCandidates((prev) => [...prev, candidate]);
+                              }}
+                              className="flex w-full items-center justify-between rounded-2xl bg-white px-4 py-3 text-left shadow-sm"
+                            >
+                              <span className="text-sm">{formatCandidateStart(candidate.startTime)}</span>
+                              <span className="material-symbols-rounded text-sm text-[var(--muted)]">add</span>
+                            </button>
+                          ))}
+                        </div>
                       </div>
                     )}
 
-                    <div className="mt-3">
+                    {/* 手動追加 */}
+                    <div>
                       {showManualDateInput ? (
                         <div className="flex flex-col gap-2">
                           <input
@@ -1410,13 +1387,9 @@ function EventCreatePageContent() {
                                 if (!manualDateInput) return;
                                 const start = new Date(manualDateInput);
                                 const end = new Date(start.getTime() + 2 * 60 * 60 * 1000);
-                                setManualTimeCandidates((prev) => [
+                                setActiveCandidates((prev) => [
                                   ...prev,
-                                  {
-                                    id: generateId(),
-                                    startTime: start.toISOString(),
-                                    endTime: end.toISOString(),
-                                  },
+                                  { id: generateId(), startTime: start.toISOString(), endTime: end.toISOString() },
                                 ]);
                                 setManualDateInput("");
                                 setShowManualDateInput(false);
@@ -1427,10 +1400,7 @@ function EventCreatePageContent() {
                               追加
                             </button>
                             <button
-                              onClick={() => {
-                                setManualDateInput("");
-                                setShowManualDateInput(false);
-                              }}
+                              onClick={() => { setManualDateInput(""); setShowManualDateInput(false); }}
                               className="flex-1 rounded-full bg-white px-4 py-2 text-xs font-semibold text-[var(--muted)] shadow-sm"
                             >
                               キャンセル
@@ -1447,12 +1417,6 @@ function EventCreatePageContent() {
                         </button>
                       )}
                     </div>
-
-                    {allUserTimeCandidates.length === 0 && (
-                      <p className="mt-2 text-xs text-rose-500">
-                        候補を1件以上選択または追加してください。
-                      </p>
-                    )}
                   </div>
                 )}
 

--- a/app/events/new/page.tsx
+++ b/app/events/new/page.tsx
@@ -57,7 +57,7 @@ type EventUpdateComparable = {
   eventArea: string;
   visibility: "public" | "limited" | "private";
   capacity: number;
-  timeSetting: "auto" | "manual";
+  timeSetting: "auto" | "candidates" | "manual";
   placeSetting: "auto" | "manual";
   fixedStartTime: string | null;
   fixedPlace: {
@@ -65,6 +65,19 @@ type EventUpdateComparable = {
     name: string;
     address: string;
   } | null;
+};
+
+type SuggestedCandidate = {
+  id: string;
+  startTime: string;
+  endTime: string;
+  selected: boolean;
+};
+
+type ManualCandidate = {
+  id: string;
+  startTime: string;
+  endTime: string;
 };
 
 type Step = 1 | 2 | 3 | 4 | 5 | 6;
@@ -94,7 +107,18 @@ const purposeElementOptions = [
   "少人数",
 ];
 
-const settingOptions: Array<{
+const timeSettingOptions: Array<{
+  value: "auto" | "candidates" | "manual";
+  label: string;
+  caption: string;
+  recommended?: boolean;
+}> = [
+  { value: "auto", label: "おまかせ", caption: "直近の日程を自動で提案", recommended: true },
+  { value: "candidates", label: "日程候補を設定する", caption: "日程の選択肢を手動で追加" },
+  { value: "manual", label: "固定", caption: "既に確定している日程を設定" },
+];
+
+const placeSettingOptions: Array<{
   value: "auto" | "manual";
   label: string;
   caption: string;
@@ -106,6 +130,21 @@ const settingOptions: Array<{
 
 const plusButtonClass =
   "grid h-7 w-7 place-items-center rounded-full border border-dashed border-gray-400 bg-gray-50 text-gray-500";
+
+const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
+const WEEKDAY_LABELS = ["日", "月", "火", "水", "木", "金", "土"] as const;
+
+const formatCandidateTime = (isoString: string) => {
+  const jst = new Date(new Date(isoString).getTime() + JST_OFFSET_MS);
+  const month = jst.getUTCMonth() + 1;
+  const day = jst.getUTCDate();
+  const weekday = WEEKDAY_LABELS[jst.getUTCDay()];
+  const h = String(jst.getUTCHours()).padStart(2, "0");
+  const m = String(jst.getUTCMinutes()).padStart(2, "0");
+  return `${month}月${day}日 (${weekday}) ${h}:${m}`;
+};
+
+const generateId = () => Math.random().toString(36).slice(2);
 
 const buildAutoTitle = (elements: string[]) => {
   if (elements.length === 0) return "";
@@ -158,7 +197,7 @@ const buildComparableFromEvent = (event: EventEditResponse): EventUpdateComparab
     eventArea: toComparableText(event.area),
     visibility: event.visibility,
     capacity: normalizeCapacity(event.capacity),
-    timeSetting: hasFixedStart ? "manual" : "auto",
+    timeSetting: hasFixedStart ? "manual" : ("auto" as "auto" | "candidates" | "manual"),
     placeSetting: hasFixedPlace ? "manual" : "auto",
     fixedStartTime: hasFixedStart ? toDatetimeLocalValue(event.fixedStartTime) : null,
     fixedPlace: hasFixedPlace
@@ -212,9 +251,14 @@ function EventCreatePageContent() {
   const [isAreaOverlayOpen, setIsAreaOverlayOpen] = useState(false);
   const [areaMessage, setAreaMessage] = useState<string | null>(null);
 
-  const [timeSetting, setTimeSetting] = useState<"auto" | "manual">("auto");
+  const [timeSetting, setTimeSetting] = useState<"auto" | "candidates" | "manual">("auto");
   const [placeSetting, setPlaceSetting] = useState<"auto" | "manual">("auto");
   const [fixedStart, setFixedStart] = useState("");
+  const [suggestedCandidates, setSuggestedCandidates] = useState<SuggestedCandidate[]>([]);
+  const [isSuggestionsLoading, setIsSuggestionsLoading] = useState(false);
+  const [manualTimeCandidates, setManualTimeCandidates] = useState<ManualCandidate[]>([]);
+  const [manualDateInput, setManualDateInput] = useState("");
+  const [showManualDateInput, setShowManualDateInput] = useState(false);
   const [selectedPlace, setSelectedPlace] = useState<PlaceResult | null>(null);
   const [candidatePlaces, setCandidatePlaces] = useState<PlaceResult[]>([]);
   const [eventComment, setEventComment] = useState("");
@@ -365,6 +409,43 @@ function EventCreatePageContent() {
   }, [editEventId, isEditMode, userId]);
 
   useEffect(() => {
+    if (timeSetting !== "candidates" || !userId) {
+      setSuggestedCandidates([]);
+      return;
+    }
+
+    let active = true;
+    setIsSuggestionsLoading(true);
+
+    const loadSuggestions = async () => {
+      const response = await fetch(
+        `/api/profiles/${encodeURIComponent(userId)}/time-suggestions`,
+        { cache: "no-store" }
+      );
+      if (!active) return;
+      if (response.ok) {
+        const data = (await response.json()) as {
+          candidates: { startTime: string; endTime: string }[];
+        };
+        setSuggestedCandidates(
+          data.candidates.map((c) => ({
+            id: generateId(),
+            startTime: c.startTime,
+            endTime: c.endTime,
+            selected: true,
+          }))
+        );
+      }
+      setIsSuggestionsLoading(false);
+    };
+
+    loadSuggestions();
+    return () => {
+      active = false;
+    };
+  }, [timeSetting, userId]);
+
+  useEffect(() => {
     if (!userId) {
       setFriends([]);
       return;
@@ -406,7 +487,22 @@ function EventCreatePageContent() {
     previousAutoTitleRef.current = autoTitle;
   }, [autoTitle, eventTitleInput, isTitleCustomized]);
 
-  const isTimeManualValid = timeSetting === "manual" ? Boolean(fixedStart) : true;
+  const allUserTimeCandidates = useMemo(
+    () => [
+      ...suggestedCandidates
+        .filter((c) => c.selected)
+        .map((c) => ({ startTime: c.startTime, endTime: c.endTime })),
+      ...manualTimeCandidates.map((c) => ({ startTime: c.startTime, endTime: c.endTime })),
+    ],
+    [suggestedCandidates, manualTimeCandidates]
+  );
+
+  const isTimeManualValid =
+    timeSetting === "manual"
+      ? Boolean(fixedStart)
+      : timeSetting === "candidates"
+        ? allUserTimeCandidates.length > 0
+        : true;
   const isPlaceManualValid = placeSetting === "manual" ? Boolean(selectedPlace) : true;
   const derivedScheduleMode: "fixed" | "candidate" =
     timeSetting === "manual" && placeSetting === "manual" ? "fixed" : "candidate";
@@ -462,6 +558,12 @@ function EventCreatePageContent() {
     }
     if (timeSetting === "manual") {
       return "日程は固定し、場所は候補から決定します。";
+    }
+    if (timeSetting === "candidates" && placeSetting === "manual") {
+      return "日程候補を設定し、場所は固定して作成します。";
+    }
+    if (timeSetting === "candidates") {
+      return "日程候補から参加者と日程を決定します。";
     }
     if (placeSetting === "manual") {
       return "場所は固定し、日程は候補から決定します。";
@@ -685,6 +787,7 @@ function EventCreatePageContent() {
         timeSetting,
         placeSetting,
         fixedStartTime: normalizedFixedStart,
+        userTimeCandidates: timeSetting === "candidates" ? allUserTimeCandidates : undefined,
         fixedPlace:
           placeSetting === "manual" && selectedPlace
             ? {
@@ -1186,9 +1289,192 @@ function EventCreatePageContent() {
 
             {(!isFocusMode || capacityTouched) && (
               <section className="rounded-3xl bg-white p-4 shadow-sm">
+                <h2 className="text-sm font-semibold">日程の設定</h2>
+                <p className="mt-1 text-xs text-[var(--muted)]">
+                  日程の決め方を選択してください。
+                </p>
+                <div className="mt-3 space-y-2">
+                  {timeSettingOptions.map((mode) => (
+                    <button
+                      key={mode.value}
+                      onClick={() => setTimeSetting(mode.value)}
+                      className={`flex w-full items-center justify-between rounded-2xl px-4 py-3 text-left ${
+                        timeSetting === mode.value
+                          ? "bg-orange-50 shadow-md"
+                          : "bg-white shadow-sm"
+                      }`}
+                    >
+                      <div>
+                        <p className="text-sm font-semibold">{mode.label}</p>
+                        <p className="text-xs text-[var(--muted)]">{mode.caption}</p>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        {mode.recommended && (
+                          <span className="rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-semibold text-amber-700">
+                            推奨
+                          </span>
+                        )}
+                        <span className="text-xs font-semibold text-[var(--muted)]">
+                          {timeSetting === mode.value ? "選択中" : "未選択"}
+                        </span>
+                      </div>
+                    </button>
+                  ))}
+                </div>
+
+                {timeSetting === "candidates" && (
+                  <div className="mt-4">
+                    <p className="mb-2 text-xs font-semibold text-[var(--foreground)]">
+                      提案候補（プロフィールの空き日程から）
+                    </p>
+                    {isSuggestionsLoading ? (
+                      <p className="text-xs text-[var(--muted)]">候補を取得中...</p>
+                    ) : suggestedCandidates.length === 0 ? (
+                      <p className="text-xs text-[var(--muted)]">
+                        プロフィールに空き日程が設定されていません。下の手動追加から日程を入力してください。
+                      </p>
+                    ) : (
+                      <div className="space-y-2">
+                        {suggestedCandidates.map((candidate) => (
+                          <button
+                            key={candidate.id}
+                            onClick={() =>
+                              setSuggestedCandidates((prev) =>
+                                prev.map((c) =>
+                                  c.id === candidate.id ? { ...c, selected: !c.selected } : c
+                                )
+                              )
+                            }
+                            className={`flex w-full items-center gap-3 rounded-2xl px-4 py-3 text-left ${
+                              candidate.selected ? "bg-orange-50 shadow-md" : "bg-white shadow-sm"
+                            }`}
+                          >
+                            <span
+                              className={`grid h-5 w-5 flex-shrink-0 place-items-center rounded-full border ${
+                                candidate.selected
+                                  ? "border-[var(--accent)] bg-[var(--accent)] text-white"
+                                  : "border-gray-300 bg-white"
+                              }`}
+                            >
+                              {candidate.selected && (
+                                <span className="material-symbols-rounded text-xs">check</span>
+                              )}
+                            </span>
+                            <span className="text-sm">
+                              {formatCandidateTime(candidate.startTime)}〜{formatCandidateTime(candidate.endTime).split(" ").pop()}
+                            </span>
+                          </button>
+                        ))}
+                      </div>
+                    )}
+
+                    {manualTimeCandidates.length > 0 && (
+                      <div className="mt-3">
+                        <p className="mb-2 text-xs font-semibold text-[var(--foreground)]">手動追加した候補</p>
+                        <div className="space-y-2">
+                          {manualTimeCandidates.map((candidate) => (
+                            <div
+                              key={candidate.id}
+                              className="flex items-center justify-between rounded-2xl bg-orange-50 px-4 py-3 shadow-sm"
+                            >
+                              <span className="text-sm">{formatCandidateTime(candidate.startTime)}</span>
+                              <button
+                                onClick={() =>
+                                  setManualTimeCandidates((prev) =>
+                                    prev.filter((c) => c.id !== candidate.id)
+                                  )
+                                }
+                                className="grid h-6 w-6 place-items-center rounded-full bg-white text-[var(--muted)] shadow-sm"
+                                aria-label="削除"
+                              >
+                                <span className="material-symbols-rounded text-sm">close</span>
+                              </button>
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+
+                    <div className="mt-3">
+                      {showManualDateInput ? (
+                        <div className="flex flex-col gap-2">
+                          <input
+                            type="datetime-local"
+                            value={manualDateInput}
+                            onChange={(e) => setManualDateInput(e.target.value)}
+                            className="rounded-2xl bg-white px-4 py-3 text-sm shadow-sm"
+                          />
+                          <div className="flex gap-2">
+                            <button
+                              onClick={() => {
+                                if (!manualDateInput) return;
+                                const start = new Date(manualDateInput);
+                                const end = new Date(start.getTime() + 2 * 60 * 60 * 1000);
+                                setManualTimeCandidates((prev) => [
+                                  ...prev,
+                                  {
+                                    id: generateId(),
+                                    startTime: start.toISOString(),
+                                    endTime: end.toISOString(),
+                                  },
+                                ]);
+                                setManualDateInput("");
+                                setShowManualDateInput(false);
+                              }}
+                              disabled={!manualDateInput}
+                              className="flex-1 rounded-full bg-[var(--accent)] px-4 py-2 text-xs font-semibold text-white disabled:opacity-50"
+                            >
+                              追加
+                            </button>
+                            <button
+                              onClick={() => {
+                                setManualDateInput("");
+                                setShowManualDateInput(false);
+                              }}
+                              className="flex-1 rounded-full bg-white px-4 py-2 text-xs font-semibold text-[var(--muted)] shadow-sm"
+                            >
+                              キャンセル
+                            </button>
+                          </div>
+                        </div>
+                      ) : (
+                        <button
+                          onClick={() => setShowManualDateInput(true)}
+                          className="flex items-center gap-1 rounded-full bg-white px-4 py-2 text-xs font-semibold text-[var(--muted)] shadow-sm"
+                        >
+                          <span className="material-symbols-rounded text-sm">add</span>
+                          日程を手動追加
+                        </button>
+                      )}
+                    </div>
+
+                    {allUserTimeCandidates.length === 0 && (
+                      <p className="mt-2 text-xs text-rose-500">
+                        候補を1件以上選択または追加してください。
+                      </p>
+                    )}
+                  </div>
+                )}
+
+                {timeSetting === "manual" && (
+                  <label className="mt-3 flex flex-col gap-2 text-sm">
+                    開始日時
+                    <input
+                      type="datetime-local"
+                      value={fixedStart}
+                      onChange={(event) => setFixedStart(event.target.value)}
+                      className="rounded-2xl bg-white px-4 py-3 shadow-sm"
+                    />
+                  </label>
+                )}
+              </section>
+            )}
+
+            {(!isFocusMode || capacityTouched) && (
+              <section className="rounded-3xl bg-white p-4 shadow-sm">
                 <h2 className="text-sm font-semibold">詳細設定（任意）</h2>
                 <p className="mt-1 text-xs text-[var(--muted)]">
-                  日程・場所を手動設定したい場合のみ選択してください。
+                  場所を手動設定したい場合のみ選択してください。
                 </p>
 
                 <label className="mt-4 block text-sm">
@@ -1201,53 +1487,10 @@ function EventCreatePageContent() {
                   />
                 </label>
 
-                <div className="mt-4">
-                  <p className="mb-2 text-sm font-medium">日程の設定</p>
-                  <div className="space-y-2">
-                    {settingOptions.map((mode) => (
-                      <button
-                        key={mode.value}
-                        onClick={() => setTimeSetting(mode.value)}
-                        className={`flex w-full items-center justify-between rounded-2xl px-4 py-3 text-left ${
-                          timeSetting === mode.value
-                            ? "bg-orange-50 shadow-md"
-                            : "bg-white shadow-sm"
-                        }`}
-                      >
-                        <div>
-                          <p className="text-sm font-semibold">{mode.label}</p>
-                          <p className="text-xs text-[var(--muted)]">{mode.caption}</p>
-                        </div>
-                        <div className="flex items-center gap-2">
-                          {mode.recommended && (
-                            <span className="rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-semibold text-amber-700">
-                              推奨
-                            </span>
-                          )}
-                          <span className="text-xs font-semibold text-[var(--muted)]">
-                            {timeSetting === mode.value ? "選択中" : "未選択"}
-                          </span>
-                        </div>
-                      </button>
-                    ))}
-                  </div>
-                  {timeSetting === "manual" && (
-                    <label className="mt-3 flex flex-col gap-2 text-sm">
-                      開始日時
-                      <input
-                        type="datetime-local"
-                        value={fixedStart}
-                        onChange={(event) => setFixedStart(event.target.value)}
-                        className="rounded-2xl bg-white px-4 py-3 shadow-sm"
-                      />
-                    </label>
-                  )}
-                </div>
-
                 <div className="mt-5">
                   <p className="mb-2 text-sm font-medium">場所の設定</p>
                   <div className="space-y-2">
-                    {settingOptions.map((mode) => (
+                    {placeSettingOptions.map((mode) => (
                       <button
                         key={`place-${mode.value}`}
                         onClick={() => setPlaceSetting(mode.value)}

--- a/app/events/new/page.tsx
+++ b/app/events/new/page.tsx
@@ -48,6 +48,7 @@ type EventEditResponse = {
   owner: {
     userId: string;
   };
+  timeCandidates: { startTime: string; endTime: string }[];
   placeCandidates: PlaceResult[];
 };
 
@@ -60,6 +61,7 @@ type EventUpdateComparable = {
   timeSetting: "auto" | "candidates" | "manual";
   placeSetting: "auto" | "manual";
   fixedStartTime: string | null;
+  candidateStartTimes: string;
   fixedPlace: {
     placeId: string;
     name: string;
@@ -183,6 +185,11 @@ const buildComparableFromEvent = (event: EventEditResponse): EventUpdateComparab
   const hasFixedPlace = Boolean(
     event.fixedPlaceId && event.fixedPlaceName && event.fixedPlaceAddress
   );
+  const resolvedTimeSetting: "auto" | "candidates" | "manual" = hasFixedStart
+    ? "manual"
+    : event.timeCandidates.length > 0
+      ? "candidates"
+      : "auto";
 
   return {
     purpose: toComparableText(event.purpose),
@@ -190,9 +197,10 @@ const buildComparableFromEvent = (event: EventEditResponse): EventUpdateComparab
     eventArea: toComparableText(event.area),
     visibility: event.visibility,
     capacity: normalizeCapacity(event.capacity),
-    timeSetting: hasFixedStart ? "manual" : ("auto" as "auto" | "candidates" | "manual"),
+    timeSetting: resolvedTimeSetting,
     placeSetting: hasFixedPlace ? "manual" : "auto",
     fixedStartTime: hasFixedStart ? toDatetimeLocalValue(event.fixedStartTime) : null,
+    candidateStartTimes: [...event.timeCandidates.map((c) => c.startTime)].sort().join(","),
     fixedPlace: hasFixedPlace
       ? {
           placeId: toComparableText(event.fixedPlaceId),
@@ -368,9 +376,21 @@ function EventCreatePageContent() {
       if (fixedStart) {
         setTimeSetting("manual");
         setFixedStart(fixedStart);
+        setActiveCandidates([]);
+      } else if (event.timeCandidates && event.timeCandidates.length > 0) {
+        setTimeSetting("candidates");
+        setFixedStart("");
+        setActiveCandidates(
+          event.timeCandidates.map((c) => ({
+            id: generateId(),
+            startTime: c.startTime,
+            endTime: c.endTime,
+          }))
+        );
       } else {
         setTimeSetting("auto");
         setFixedStart("");
+        setActiveCandidates([]);
       }
 
       if (event.fixedPlaceName && event.fixedPlaceAddress && event.fixedPlaceId) {
@@ -485,6 +505,9 @@ function EventCreatePageContent() {
     [activeCandidates]
   );
 
+  const MAX_TIME_CANDIDATES = 5;
+  const isCandidateFull = activeCandidates.length >= MAX_TIME_CANDIDATES;
+
   const isTimeManualValid =
     timeSetting === "manual"
       ? Boolean(fixedStart)
@@ -506,6 +529,10 @@ function EventCreatePageContent() {
       timeSetting,
       placeSetting,
       fixedStartTime: timeSetting === "manual" ? fixedStart : null,
+      candidateStartTimes:
+        timeSetting === "candidates"
+          ? [...activeCandidates.map((c) => c.startTime)].sort().join(",")
+          : "",
       fixedPlace:
         placeSetting === "manual" && selectedPlace
           ? {
@@ -515,7 +542,7 @@ function EventCreatePageContent() {
             }
           : null,
     }),
-    [capacity, eventComment, fixedStart, placeSetting, resolvedTitle, selectedEventArea, selectedPlace, timeSetting, visibility]
+    [activeCandidates, capacity, eventComment, fixedStart, placeSetting, resolvedTitle, selectedEventArea, selectedPlace, timeSetting, visibility]
   );
 
   const hasEditChanges = useMemo(() => {
@@ -1353,15 +1380,26 @@ function EventCreatePageContent() {
                     {!isSuggestionsLoading && suggestionPool.length > 0 && (
                       <div>
                         <p className="mb-2 text-xs font-semibold text-[var(--foreground)]">提案候補</p>
+                        {isCandidateFull && (
+                          <p className="mb-2 text-xs text-[var(--muted)]">
+                            日程候補が{MAX_TIME_CANDIDATES}件に達したため追加できません。
+                          </p>
+                        )}
                         <div className="space-y-2">
                           {suggestionPool.map((candidate) => (
                             <button
                               key={candidate.id}
+                              disabled={isCandidateFull}
                               onClick={() => {
+                                if (isCandidateFull) return;
                                 setSuggestionPool((prev) => prev.filter((c) => c.id !== candidate.id));
                                 setActiveCandidates((prev) => [...prev, candidate]);
                               }}
-                              className="flex w-full items-center justify-between rounded-2xl bg-white px-4 py-3 text-left shadow-sm"
+                              className={`flex w-full items-center justify-between rounded-2xl px-4 py-3 text-left shadow-sm ${
+                                isCandidateFull
+                                  ? "cursor-not-allowed bg-gray-50 opacity-50"
+                                  : "bg-white"
+                              }`}
                             >
                               <span className="text-sm">{formatCandidateStart(candidate.startTime)}</span>
                               <span className="material-symbols-rounded text-sm text-[var(--muted)]">add</span>
@@ -1384,7 +1422,7 @@ function EventCreatePageContent() {
                           <div className="flex gap-2">
                             <button
                               onClick={() => {
-                                if (!manualDateInput) return;
+                                if (!manualDateInput || isCandidateFull) return;
                                 const start = new Date(manualDateInput);
                                 const end = new Date(start.getTime() + 2 * 60 * 60 * 1000);
                                 setActiveCandidates((prev) => [
@@ -1394,7 +1432,7 @@ function EventCreatePageContent() {
                                 setManualDateInput("");
                                 setShowManualDateInput(false);
                               }}
-                              disabled={!manualDateInput}
+                              disabled={!manualDateInput || isCandidateFull}
                               className="flex-1 rounded-full bg-[var(--accent)] px-4 py-2 text-xs font-semibold text-white disabled:opacity-50"
                             >
                               追加
@@ -1410,10 +1448,15 @@ function EventCreatePageContent() {
                       ) : (
                         <button
                           onClick={() => setShowManualDateInput(true)}
-                          className="flex items-center gap-1 rounded-full bg-white px-4 py-2 text-xs font-semibold text-[var(--muted)] shadow-sm"
+                          disabled={isCandidateFull}
+                          className={`flex items-center gap-1 rounded-full px-4 py-2 text-xs font-semibold shadow-sm ${
+                            isCandidateFull
+                              ? "cursor-not-allowed bg-gray-50 text-gray-400 opacity-50"
+                              : "bg-white text-[var(--muted)]"
+                          }`}
                         >
                           <span className="material-symbols-rounded text-sm">add</span>
-                          日程を手動追加
+                          日程を手動追加{isCandidateFull ? "（上限に達しました）" : ""}
                         </button>
                       )}
                     </div>

--- a/app/events/new/page.tsx
+++ b/app/events/new/page.tsx
@@ -279,6 +279,7 @@ function EventCreatePageContent() {
   const [submitMessage, setSubmitMessage] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const submitLockRef = useRef(false);
+  const hasFetchedSuggestionsRef = useRef(false);
 
   const purposeSectionRef = useRef<HTMLElement | null>(null);
   const visibilitySectionRef = useRef<HTMLElement | null>(null);
@@ -422,12 +423,10 @@ function EventCreatePageContent() {
   }, [editEventId, isEditMode, userId]);
 
   useEffect(() => {
-    if (timeSetting !== "candidates" || !userId) {
-      setActiveCandidates([]);
-      setSuggestionPool([]);
-      return;
-    }
+    if (timeSetting !== "candidates" || !userId) return;
+    if (hasFetchedSuggestionsRef.current) return;
 
+    hasFetchedSuggestionsRef.current = true;
     let active = true;
     setIsSuggestionsLoading(true);
 
@@ -442,8 +441,10 @@ function EventCreatePageContent() {
           defaults: { startTime: string; endTime: string }[];
           suggestions: { startTime: string; endTime: string }[];
         };
-        setActiveCandidates(
-          data.defaults.map((c) => ({ id: generateId(), startTime: c.startTime, endTime: c.endTime }))
+        setActiveCandidates((prev) =>
+          prev.length === 0
+            ? data.defaults.map((c) => ({ id: generateId(), startTime: c.startTime, endTime: c.endTime }))
+            : prev
         );
         setSuggestionPool(
           data.suggestions.map((c) => ({ id: generateId(), startTime: c.startTime, endTime: c.endTime }))

--- a/app/events/new/page.tsx
+++ b/app/events/new/page.tsx
@@ -258,6 +258,8 @@ function EventCreatePageContent() {
   const [activeCandidates, setActiveCandidates] = useState<TimeCandidate[]>([]);
   const [suggestionPool, setSuggestionPool] = useState<TimeCandidate[]>([]);
   const [isSuggestionsLoading, setIsSuggestionsLoading] = useState(false);
+  const [isSuggestionsError, setIsSuggestionsError] = useState(false);
+  const [suggestionRetryCount, setSuggestionRetryCount] = useState(0);
   const [manualDateInput, setManualDateInput] = useState("");
   const [showManualDateInput, setShowManualDateInput] = useState(false);
   const [selectedPlace, setSelectedPlace] = useState<PlaceResult | null>(null);
@@ -426,38 +428,48 @@ function EventCreatePageContent() {
     if (timeSetting !== "candidates" || !userId) return;
     if (hasFetchedSuggestionsRef.current) return;
 
-    hasFetchedSuggestionsRef.current = true;
     let active = true;
     setIsSuggestionsLoading(true);
+    setIsSuggestionsError(false);
 
     const loadSuggestions = async () => {
-      const response = await fetch(
-        `/api/profiles/${encodeURIComponent(userId)}/time-suggestions`,
-        { cache: "no-store" }
-      );
-      if (!active) return;
-      if (response.ok) {
-        const data = (await response.json()) as {
-          defaults: { startTime: string; endTime: string }[];
-          suggestions: { startTime: string; endTime: string }[];
-        };
-        setActiveCandidates((prev) =>
-          prev.length === 0
-            ? data.defaults.map((c) => ({ id: generateId(), startTime: c.startTime, endTime: c.endTime }))
-            : prev
+      try {
+        const response = await fetch(
+          `/api/profiles/${encodeURIComponent(userId)}/time-suggestions`,
+          { cache: "no-store" }
         );
-        setSuggestionPool(
-          data.suggestions.map((c) => ({ id: generateId(), startTime: c.startTime, endTime: c.endTime }))
-        );
+        if (!active) return;
+        if (response.ok) {
+          const data = (await response.json()) as {
+            defaults: { startTime: string; endTime: string }[];
+            suggestions: { startTime: string; endTime: string }[];
+          };
+          hasFetchedSuggestionsRef.current = true;
+          setActiveCandidates((prev) =>
+            prev.length === 0
+              ? data.defaults.map((c) => ({ id: generateId(), startTime: c.startTime, endTime: c.endTime }))
+              : prev
+          );
+          setSuggestionPool(
+            data.suggestions.map((c) => ({ id: generateId(), startTime: c.startTime, endTime: c.endTime }))
+          );
+        } else {
+          if (!active) return;
+          setIsSuggestionsError(true);
+        }
+      } catch {
+        if (!active) return;
+        setIsSuggestionsError(true);
+      } finally {
+        if (active) setIsSuggestionsLoading(false);
       }
-      setIsSuggestionsLoading(false);
     };
 
     loadSuggestions();
     return () => {
       active = false;
     };
-  }, [timeSetting, userId]);
+  }, [timeSetting, userId, suggestionRetryCount]);
 
   useEffect(() => {
     if (!userId) {
@@ -1345,6 +1357,21 @@ function EventCreatePageContent() {
                       <p className="mb-2 text-xs font-semibold text-[var(--foreground)]">日程候補</p>
                       {isSuggestionsLoading ? (
                         <p className="text-xs text-[var(--muted)]">候補を取得中...</p>
+                      ) : isSuggestionsError ? (
+                        <div className="space-y-2">
+                          <p className="text-xs text-rose-500">
+                            日程候補の取得に失敗しました。提案候補が表示されない場合は、日程を手動で追加してください。
+                          </p>
+                          <button
+                            onClick={() => {
+                              setIsSuggestionsError(false);
+                              setSuggestionRetryCount((c) => c + 1);
+                            }}
+                            className="text-xs text-[var(--accent)] underline"
+                          >
+                            再試行する
+                          </button>
+                        </div>
                       ) : activeCandidates.length === 0 ? (
                         <p className="text-xs text-[var(--muted)]">
                           候補がありません。下の「提案候補」から選択するか、日程を手動追加してください。

--- a/lib/event-time-candidates.ts
+++ b/lib/event-time-candidates.ts
@@ -130,7 +130,8 @@ export const buildDefaultTimeCandidates = (
   dayPriorityByWeekday?: Record<WeekdayKey, number>,
   baseNow: Date = new Date(),
   minOffset: number = MIN_CANDIDATE_OFFSET_DAYS,
-  maxCandidates: number = 3
+  maxCandidates: number = 3,
+  windowDays: number = 28
 ) => {
   const weekdaySlots = availability?.weekdaySlots;
   const candidates: Array<TimeCandidateInput & { dayKey: WeekdayKey; priority: number }> = [];
@@ -140,7 +141,7 @@ export const buildDefaultTimeCandidates = (
 
   if (weekdaySlots) {
     let offset = minOffset;
-    while (offset < minOffset + 28) {
+    while (offset < minOffset + windowDays) {
       const jstVirtualDate = getJstVirtualDateAtOffset(baseNow, offset);
       const dayKey = weekdayKeyByIndex[jstVirtualDate.getUTCDay()];
       if (!dayKey) {
@@ -195,7 +196,7 @@ export const buildDefaultTimeCandidates = (
     .filter((day: number | undefined) => day !== undefined);
   let offset = minOffset;
 
-  while (offset < minOffset + 14) {
+  while (offset < minOffset + windowDays) {
     const jstVirtualDate = getJstVirtualDateAtOffset(baseNow, offset);
     const jstDayIndex = jstVirtualDate.getUTCDay();
     const dayKey = weekdayKeyByIndex[jstDayIndex];

--- a/lib/event-time-candidates.ts
+++ b/lib/event-time-candidates.ts
@@ -107,7 +107,8 @@ export const buildDayPriorityByWeekday = (availabilities: unknown[]) => {
 };
 
 const pickTopTimeCandidates = (
-  pool: Array<TimeCandidateInput & { dayKey: WeekdayKey; priority: number }>
+  pool: Array<TimeCandidateInput & { dayKey: WeekdayKey; priority: number }>,
+  limit: number = 3
 ) =>
   pool
     .sort((a, b) => {
@@ -116,7 +117,7 @@ const pickTopTimeCandidates = (
       }
       return a.startTime.getTime() - b.startTime.getTime();
     })
-    .slice(0, 3)
+    .slice(0, limit)
     .map(({ startTime, endTime, score, source }) => ({
       startTime,
       endTime,
@@ -127,7 +128,9 @@ const pickTopTimeCandidates = (
 export const buildDefaultTimeCandidates = (
   availability?: AvailabilityInput,
   dayPriorityByWeekday?: Record<WeekdayKey, number>,
-  baseNow: Date = new Date()
+  baseNow: Date = new Date(),
+  minOffset: number = MIN_CANDIDATE_OFFSET_DAYS,
+  maxCandidates: number = 3
 ) => {
   const weekdaySlots = availability?.weekdaySlots;
   const candidates: Array<TimeCandidateInput & { dayKey: WeekdayKey; priority: number }> = [];
@@ -136,8 +139,8 @@ export const buildDefaultTimeCandidates = (
     dayPriorityByWeekday?.[dayKey] ?? 0;
 
   if (weekdaySlots) {
-    let offset = MIN_CANDIDATE_OFFSET_DAYS;
-    while (offset < 21) {
+    let offset = minOffset;
+    while (offset < minOffset + 28) {
       const jstVirtualDate = getJstVirtualDateAtOffset(baseNow, offset);
       const dayKey = weekdayKeyByIndex[jstVirtualDate.getUTCDay()];
       if (!dayKey) {
@@ -182,7 +185,7 @@ export const buildDefaultTimeCandidates = (
   }
 
   if (candidates.length > 0) {
-    return pickTopTimeCandidates(candidates);
+    return pickTopTimeCandidates(candidates, maxCandidates);
   }
 
   const startRange = availability?.timeRanges?.[0]?.start ?? "19:00";
@@ -190,9 +193,9 @@ export const buildDefaultTimeCandidates = (
   const availableDays = availability?.days
     ?.map((day: string) => dayIndex[day])
     .filter((day: number | undefined) => day !== undefined);
-  let offset = MIN_CANDIDATE_OFFSET_DAYS;
+  let offset = minOffset;
 
-  while (offset < 14) {
+  while (offset < minOffset + 14) {
     const jstVirtualDate = getJstVirtualDateAtOffset(baseNow, offset);
     const jstDayIndex = jstVirtualDate.getUTCDay();
     const dayKey = weekdayKeyByIndex[jstDayIndex];
@@ -230,11 +233,11 @@ export const buildDefaultTimeCandidates = (
   }
 
   if (candidates.length === 0) {
-    const fallbackVirtualDate = getJstVirtualDateAtOffset(baseNow, MIN_CANDIDATE_OFFSET_DAYS);
+    const fallbackVirtualDate = getJstVirtualDateAtOffset(baseNow, minOffset);
     const fallback = createUtcDateFromJstVirtualDate(fallbackVirtualDate, 19, 0);
     const end = createUtcDateFromJstVirtualDate(fallbackVirtualDate, 22, 0);
     return [{ startTime: fallback, endTime: end, score: 0, source: "system" as const }];
   }
 
-  return pickTopTimeCandidates(candidates);
+  return pickTopTimeCandidates(candidates, maxCandidates);
 };


### PR DESCRIPTION
## 概要

イベント作成画面の「日程の設定」を「詳細設定」から切り出して独立したセクションとして配置し、選択肢を3種類に拡張した。

**関連ドキュメント**
- Closes #67

## 影響範囲

- DB変更なし（既存の `ScheduleMode` enum `candidate` と `EventTimeCandidate` テーブルで吸収）
- 既存の「おまかせ」「固定」モードの挙動は変更なし
- 新規追加エンドポイント: `GET /api/profiles/[id]/time-suggestions`
- 既存エンドポイントへの追加: POST/PATCH `/api/events` が `timeSetting="candidates"` と `userTimeCandidates` を受け付けるように変更

## 変更点

**AS IS**
- 「日程の設定」は「詳細設定」セクション内にあり、「おまかせ」「設定する」の2択のみ

**TO BE**
- 「日程の設定」を「詳細設定」のすぐ上に独立したセクションとして配置
- 選択肢が以下の3種類に変更:
  1. **おまかせ（直近の日程を自動で提案）** — 従来の「おまかせ」と同等
  2. **日程候補を設定する（日程の選択肢を手動で追加）** — 新規。プロフィールの空き日程から候補を自動提案し、さらに datetime-local UI で任意日時を手動追加できる
  3. **固定（既に確定している日程を設定）** — 従来の「設定する」と同等

## QA 観点

- 「おまかせ」を選択してイベント作成 → 従来通りシステムが日程候補を自動生成すること
- 「固定」を選択して開始日時を入力しイベント作成 → `fixedStartTime` がDBに保存されること
- 「日程候補を設定する」を選択 → プロフィールの空き日程から候補リストが表示されること
- 候補リストからチェックを外すと選択解除され、チェックで再選択できること
- 「日程を手動追加」ボタンで datetime-local が表示され、入力・追加すると候補リストに追加されること
- 手動追加候補の「×」ボタンで削除できること
- 候補が0件の状態では作成ボタンが無効になること
- 選択・手動追加した候補が `EventTimeCandidate` に保存されること

## 動作確認ケース

- [ ] 「おまかせ」→ 作成 → イベント詳細で日程候補が自動生成されている
- [ ] 「固定」→ 日時入力 → 作成 → イベント詳細で固定日程が表示されている
- [ ] 「日程候補を設定する」→ 提案候補が表示される → 一部チェック外す → 手動追加 → 作成 → イベント詳細で設定した候補が表示されている
- [ ] 候補0件で作成ボタンが押せないこと

## レビュアーに特に見て欲しいポイント

- `app/api/profiles/[id]/time-suggestions/route.ts` — 新規エンドポイントのセキュリティ（認証なしで誰でも呼べる設計で良いか）
- `app/events/new/page.tsx` の `allUserTimeCandidates` useMemo — candidates モードから別モードに切り替えた際にstateがリセットされるか