### PR TITLE
[FEAT] イベント作成の場所設定を3種類に拡張し詳細設定から独立させる

### DIFF
--- a/app/api/events/[id]/route.ts
+++ b/app/api/events/[id]/route.ts
@@ -268,7 +268,7 @@ export async function PATCH(
     visibility?: "public" | "limited" | "private";
     capacity?: number;
     timeSetting?: "auto" | "candidates" | "manual";
-    placeSetting?: "auto" | "manual";
+    placeSetting?: "auto" | "candidates" | "manual";
     fixedStartTime?: string;
     fixedPlace?: {
       placeId?: string;
@@ -300,6 +300,17 @@ export async function PATCH(
   ) {
     return NextResponse.json(
       { message: "userTimeCandidates must not be empty when timeSetting is candidates" },
+      { status: 400 }
+    );
+  }
+
+  if (
+    body.placeSetting === "candidates" &&
+    body.candidatePlaces !== undefined &&
+    body.candidatePlaces.length === 0
+  ) {
+    return NextResponse.json(
+      { message: "candidatePlaces must not be empty when placeSetting is candidates" },
       { status: 400 }
     );
   }
@@ -340,7 +351,9 @@ export async function PATCH(
     body.timeSetting === "candidates" ||
     body.timeSetting === "manual";
   const hasPlaceSetting =
-    body.placeSetting === "auto" || body.placeSetting === "manual";
+    body.placeSetting === "auto" ||
+    body.placeSetting === "candidates" ||
+    body.placeSetting === "manual";
   const hasFixedPlacePayload = body.fixedPlace !== undefined;
 
   const currentTimeSetting: "auto" | "manual" = event.fixedStartTime
@@ -433,11 +446,17 @@ export async function PATCH(
     shouldRegenerateTimeCandidates ||
     shouldReplaceWithUserCandidates;
 
+  const isPlaceCandidatesMode = body.placeSetting === "candidates";
   const shouldRegeneratePlaceCandidates =
     nextPlaceSetting === "auto" &&
     (currentPlaceSetting === "manual" || event.placeCandidates.length === 0);
+  const shouldReplaceWithUserPlaceCandidates =
+    isPlaceCandidatesMode &&
+    body.candidatePlaces != null &&
+    body.candidatePlaces.length > 0;
 
-  let shouldDeletePlaceCandidates = shouldRegeneratePlaceCandidates;
+  let shouldDeletePlaceCandidates =
+    shouldRegeneratePlaceCandidates || shouldReplaceWithUserPlaceCandidates;
 
   if (hasPlaceSetting && body.placeSetting === "manual") {
     const sourceFixedPlace =
@@ -475,7 +494,10 @@ export async function PATCH(
     if (currentPlaceSetting !== "manual" || fixedPlaceChanged) {
       shouldDeletePlaceCandidates = true;
     }
-  } else if (hasPlaceSetting && body.placeSetting === "auto") {
+  } else if (
+    hasPlaceSetting &&
+    (body.placeSetting === "auto" || body.placeSetting === "candidates")
+  ) {
     if (currentPlaceSetting === "manual") {
       updateData.fixedPlaceId = null;
       updateData.fixedPlaceName = null;
@@ -526,7 +548,23 @@ export async function PATCH(
     }
   }
 
-  if (shouldDeletePlaceCandidates) {
+  if (shouldDeletePlaceCandidates && shouldReplaceWithUserPlaceCandidates && body.candidatePlaces) {
+    const parsedPlaceCandidates = body.candidatePlaces.slice(0, 5).map((c) => ({
+      eventId: id,
+      placeId: c.placeId,
+      name: c.name,
+      address: c.address,
+      lat: c.lat,
+      lng: c.lng,
+      priceLevel: c.priceLevel,
+      score: 0,
+      source: "system" as const,
+    }));
+    await prisma.$transaction([
+      prisma.eventPlaceCandidate.deleteMany({ where: { eventId: id } }),
+      prisma.eventPlaceCandidate.createMany({ data: parsedPlaceCandidates }),
+    ]);
+  } else if (shouldDeletePlaceCandidates) {
     await prisma.eventPlaceCandidate.deleteMany({
       where: { eventId: id },
     });

--- a/app/api/events/[id]/route.ts
+++ b/app/api/events/[id]/route.ts
@@ -306,8 +306,7 @@ export async function PATCH(
 
   if (
     body.placeSetting === "candidates" &&
-    body.candidatePlaces !== undefined &&
-    body.candidatePlaces.length === 0
+    (!body.candidatePlaces || body.candidatePlaces.length === 0)
   ) {
     return NextResponse.json(
       { message: "candidatePlaces must not be empty when placeSetting is candidates" },
@@ -548,7 +547,15 @@ export async function PATCH(
     }
   }
 
-  if (shouldDeletePlaceCandidates && shouldReplaceWithUserPlaceCandidates && body.candidatePlaces) {
+  if (shouldReplaceWithUserPlaceCandidates && body.candidatePlaces) {
+    for (const c of body.candidatePlaces.slice(0, 5)) {
+      if (!Number.isFinite(c.lat) || !Number.isFinite(c.lng)) {
+        return NextResponse.json(
+          { message: `場所「${c.name}」の座標が不正です。再度検索してから追加してください。` },
+          { status: 400 }
+        );
+      }
+    }
     const parsedPlaceCandidates = body.candidatePlaces.slice(0, 5).map((c) => ({
       eventId: id,
       placeId: c.placeId,
@@ -560,10 +567,17 @@ export async function PATCH(
       score: 0,
       source: "system" as const,
     }));
-    await prisma.$transaction([
-      prisma.eventPlaceCandidate.deleteMany({ where: { eventId: id } }),
-      prisma.eventPlaceCandidate.createMany({ data: parsedPlaceCandidates }),
-    ]);
+    try {
+      await prisma.$transaction([
+        prisma.eventPlaceCandidate.deleteMany({ where: { eventId: id } }),
+        prisma.eventPlaceCandidate.createMany({ data: parsedPlaceCandidates }),
+      ]);
+    } catch {
+      return NextResponse.json(
+        { message: "場所候補の保存に失敗しました。再度お試しください。" },
+        { status: 500 }
+      );
+    }
   } else if (shouldDeletePlaceCandidates) {
     await prisma.eventPlaceCandidate.deleteMany({
       where: { eventId: id },

--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -320,7 +320,7 @@ export async function POST(request: Request) {
     capacity?: number;
     scheduleMode?: "fixed" | "candidate";
     timeSetting?: "auto" | "candidates" | "manual";
-    placeSetting?: "auto" | "manual";
+    placeSetting?: "auto" | "candidates" | "manual";
     fixedStartTime?: string;
     fixedPlace?: {
       placeId: string;
@@ -358,6 +358,7 @@ export async function POST(request: Request) {
   const isPlaceManual = body.placeSetting
     ? body.placeSetting === "manual"
     : legacyFixed;
+  const isPlaceCandidates = body.placeSetting === "candidates";
   const resolvedScheduleMode =
     isTimeManual && isPlaceManual ? "fixed" : "candidate";
 
@@ -371,6 +372,13 @@ export async function POST(request: Request) {
   if (isTimeCandidates && (!body.userTimeCandidates || body.userTimeCandidates.length === 0)) {
     return NextResponse.json(
       { message: "userTimeCandidates must not be empty when timeSetting is candidates" },
+      { status: 400 }
+    );
+  }
+
+  if (isPlaceCandidates && (!body.candidatePlaces || body.candidatePlaces.length === 0)) {
+    return NextResponse.json(
+      { message: "candidatePlaces must not be empty when placeSetting is candidates" },
       { status: 400 }
     );
   }

--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -568,6 +568,14 @@ export async function POST(request: Request) {
 
     if (!isPlaceManual) {
       if (body.candidatePlaces && body.candidatePlaces.length > 0) {
+        for (const c of body.candidatePlaces.slice(0, 5)) {
+          if (!Number.isFinite(c.lat) || !Number.isFinite(c.lng)) {
+            return NextResponse.json(
+              { message: `場所「${c.name}」の座標が不正です。再度検索してから追加してください。` },
+              { status: 400 }
+            );
+          }
+        }
         await prisma.eventPlaceCandidate.createMany({
           data: body.candidatePlaces.slice(0, 5).map((candidate: any) => ({
             eventId: event.id,

--- a/app/api/profiles/[id]/place-suggestions/route.ts
+++ b/app/api/profiles/[id]/place-suggestions/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getPlacesForQuery } from "@/lib/places";
+
+const DEFAULT_COUNT = 3;
+const SUGGESTION_COUNT = 5;
+const TOTAL_COUNT = DEFAULT_COUNT + SUGGESTION_COUNT;
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const { searchParams } = new URL(request.url);
+    const purpose = searchParams.get("purpose")?.trim() || "飲み";
+    const eventArea = searchParams.get("eventArea")?.trim() || "";
+
+    const profile = await prisma.profile.findUnique({
+      where: { userId: id },
+      select: { favoriteAreas: true },
+    });
+
+    const favoriteAreas: string[] = (profile?.favoriteAreas as string[]) ?? [];
+    const searchAreas = eventArea
+      ? [eventArea, ...favoriteAreas.filter((a) => a !== eventArea)]
+      : favoriteAreas;
+
+    const uniqueByPlaceId = new Map<string, object>();
+
+    for (const area of searchAreas.slice(0, 3)) {
+      const places = await getPlacesForQuery(`${area} ${purpose}`.trim());
+      for (const place of places) {
+        if (!uniqueByPlaceId.has(place.placeId)) {
+          uniqueByPlaceId.set(place.placeId, place);
+        }
+        if (uniqueByPlaceId.size >= TOTAL_COUNT) break;
+      }
+      if (uniqueByPlaceId.size >= TOTAL_COUNT) break;
+    }
+
+    if (uniqueByPlaceId.size < TOTAL_COUNT) {
+      const fallbackQuery = searchAreas[0]
+        ? `${searchAreas[0]} ${purpose}`
+        : purpose;
+      const places = await getPlacesForQuery(fallbackQuery);
+      for (const place of places) {
+        if (!uniqueByPlaceId.has(place.placeId)) {
+          uniqueByPlaceId.set(place.placeId, place);
+        }
+        if (uniqueByPlaceId.size >= TOTAL_COUNT) break;
+      }
+    }
+
+    const all = Array.from(uniqueByPlaceId.values());
+    return NextResponse.json({
+      defaults: all.slice(0, DEFAULT_COUNT),
+      suggestions: all.slice(DEFAULT_COUNT, TOTAL_COUNT),
+    });
+  } catch (error) {
+    console.error("[place-suggestions] unexpected error:", error);
+    return NextResponse.json({ message: "Internal server error" }, { status: 500 });
+  }
+}

--- a/app/events/new/page.tsx
+++ b/app/events/new/page.tsx
@@ -495,6 +495,11 @@ function EventCreatePageContent() {
     };
   }, [timeSetting, userId, suggestionRetryCount]);
 
+  const effectivePlacePurpose = useMemo(
+    () => (purposeElements.length > 0 ? purposeElements.join(" ") : "飲み"),
+    [purposeElements]
+  );
+
   useEffect(() => {
     if (placeSetting !== "candidates" || !userId) return;
 
@@ -568,11 +573,6 @@ function EventCreatePageContent() {
   const allPurposeOptions = useMemo(
     () => [...customPurposeOptions, ...purposeElementOptions],
     [customPurposeOptions]
-  );
-
-  const effectivePlacePurpose = useMemo(
-    () => (purposeElements.length > 0 ? purposeElements.join(" ") : "飲み"),
-    [purposeElements]
   );
 
   const autoTitle = useMemo(() => buildAutoTitle(purposeElements), [purposeElements]);

--- a/app/events/new/page.tsx
+++ b/app/events/new/page.tsx
@@ -208,8 +208,14 @@ const buildComparableFromEvent = (event: EventEditResponse): EventUpdateComparab
     timeSetting: resolvedTimeSetting,
     placeSetting: resolvedPlaceSetting,
     fixedStartTime: hasFixedStart ? toDatetimeLocalValue(event.fixedStartTime) : null,
-    candidateStartTimes: [...event.timeCandidates.map((c) => c.startTime)].sort().join(","),
-    candidatePlaceIds: [...(event.placeCandidates ?? []).map((p) => p.placeId)].sort().join(","),
+    candidateStartTimes:
+      resolvedTimeSetting === "candidates"
+        ? [...event.timeCandidates.map((c) => c.startTime)].sort().join(",")
+        : "",
+    candidatePlaceIds:
+      resolvedPlaceSetting === "candidates"
+        ? [...(event.placeCandidates ?? []).map((p) => p.placeId)].sort().join(",")
+        : "",
     fixedPlace: hasFixedPlace
       ? {
           placeId: toComparableText(event.fixedPlaceId),
@@ -1546,7 +1552,14 @@ function EventCreatePageContent() {
                   {placeSettingOptions.map((mode) => (
                     <button
                       key={`place-${mode.value}`}
-                      onClick={() => setPlaceSetting(mode.value)}
+                      onClick={() => {
+                        setPlaceSetting(mode.value);
+                        if (mode.value === "auto") {
+                          setPlaceQuery("");
+                          setPlaceResults([]);
+                          setSearchMessage(null);
+                        }
+                      }}
                       className={`flex w-full items-center justify-between rounded-2xl px-4 py-3 text-left ${
                         placeSetting === mode.value
                           ? "bg-orange-50 shadow-md"

--- a/app/events/new/page.tsx
+++ b/app/events/new/page.tsx
@@ -59,9 +59,10 @@ type EventUpdateComparable = {
   visibility: "public" | "limited" | "private";
   capacity: number;
   timeSetting: "auto" | "candidates" | "manual";
-  placeSetting: "auto" | "manual";
+  placeSetting: "auto" | "candidates" | "manual";
   fixedStartTime: string | null;
   candidateStartTimes: string;
+  candidatePlaceIds: string;
   fixedPlace: {
     placeId: string;
     name: string;
@@ -114,13 +115,14 @@ const timeSettingOptions: Array<{
 ];
 
 const placeSettingOptions: Array<{
-  value: "auto" | "manual";
+  value: "auto" | "candidates" | "manual";
   label: string;
   caption: string;
   recommended?: boolean;
 }> = [
   { value: "auto", label: "おまかせ", caption: "候補を自動提案", recommended: true },
-  { value: "manual", label: "設定する", caption: "自分で確定" },
+  { value: "candidates", label: "場所候補を設定する", caption: "場所の選択肢を手動で追加" },
+  { value: "manual", label: "固定", caption: "既に確定している場所を設定" },
 ];
 
 const plusButtonClass =
@@ -191,6 +193,12 @@ const buildComparableFromEvent = (event: EventEditResponse): EventUpdateComparab
       ? "candidates"
       : "auto";
 
+  const resolvedPlaceSetting: "auto" | "candidates" | "manual" = hasFixedPlace
+    ? "manual"
+    : (event.placeCandidates?.length ?? 0) > 0
+      ? "candidates"
+      : "auto";
+
   return {
     purpose: toComparableText(event.purpose),
     comment: toComparableText(event.comment),
@@ -198,9 +206,10 @@ const buildComparableFromEvent = (event: EventEditResponse): EventUpdateComparab
     visibility: event.visibility,
     capacity: normalizeCapacity(event.capacity),
     timeSetting: resolvedTimeSetting,
-    placeSetting: hasFixedPlace ? "manual" : "auto",
+    placeSetting: resolvedPlaceSetting,
     fixedStartTime: hasFixedStart ? toDatetimeLocalValue(event.fixedStartTime) : null,
     candidateStartTimes: [...event.timeCandidates.map((c) => c.startTime)].sort().join(","),
+    candidatePlaceIds: [...(event.placeCandidates ?? []).map((p) => p.placeId)].sort().join(","),
     fixedPlace: hasFixedPlace
       ? {
           placeId: toComparableText(event.fixedPlaceId),
@@ -253,7 +262,7 @@ function EventCreatePageContent() {
   const [areaMessage, setAreaMessage] = useState<string | null>(null);
 
   const [timeSetting, setTimeSetting] = useState<"auto" | "candidates" | "manual">("auto");
-  const [placeSetting, setPlaceSetting] = useState<"auto" | "manual">("auto");
+  const [placeSetting, setPlaceSetting] = useState<"auto" | "candidates" | "manual">("auto");
   const [fixedStart, setFixedStart] = useState("");
   const [activeCandidates, setActiveCandidates] = useState<TimeCandidate[]>([]);
   const [suggestionPool, setSuggestionPool] = useState<TimeCandidate[]>([]);
@@ -405,12 +414,16 @@ function EventCreatePageContent() {
           lat: 0,
           lng: 0,
         });
+        setCandidatePlaces([]);
+      } else if ((event.placeCandidates?.length ?? 0) > 0) {
+        setPlaceSetting("candidates");
+        setSelectedPlace(null);
+        setCandidatePlaces(event.placeCandidates ?? []);
       } else {
         setPlaceSetting("auto");
         setSelectedPlace(null);
+        setCandidatePlaces([]);
       }
-
-      setCandidatePlaces(event.placeCandidates ?? []);
       setEventComment(event.comment?.trim() ?? "");
       setInitialEditComparable(serializeComparable(buildComparableFromEvent(event)));
       setSubmitMessage(null);
@@ -527,7 +540,12 @@ function EventCreatePageContent() {
       : timeSetting === "candidates"
         ? allUserTimeCandidates.length > 0
         : true;
-  const isPlaceManualValid = placeSetting === "manual" ? Boolean(selectedPlace) : true;
+  const isPlaceManualValid =
+    placeSetting === "manual"
+      ? Boolean(selectedPlace)
+      : placeSetting === "candidates"
+        ? candidatePlaces.length > 0
+        : true;
   const derivedScheduleMode: "fixed" | "candidate" =
     timeSetting === "manual" && placeSetting === "manual" ? "fixed" : "candidate";
   const isProfileComplete = profileCompletionRate >= 100;
@@ -546,6 +564,10 @@ function EventCreatePageContent() {
         timeSetting === "candidates"
           ? [...activeCandidates.map((c) => c.startTime)].sort().join(",")
           : "",
+      candidatePlaceIds:
+        placeSetting === "candidates"
+          ? [...candidatePlaces.map((p) => p.placeId)].sort().join(",")
+          : "",
       fixedPlace:
         placeSetting === "manual" && selectedPlace
           ? {
@@ -555,7 +577,7 @@ function EventCreatePageContent() {
             }
           : null,
     }),
-    [activeCandidates, capacity, eventComment, fixedStart, placeSetting, resolvedTitle, selectedEventArea, selectedPlace, timeSetting, visibility]
+    [activeCandidates, candidatePlaces, capacity, eventComment, fixedStart, placeSetting, resolvedTitle, selectedEventArea, selectedPlace, timeSetting, visibility]
   );
 
   const hasEditChanges = useMemo(() => {
@@ -584,17 +606,26 @@ function EventCreatePageContent() {
     if (timeSetting === "manual" && placeSetting === "manual") {
       return "日程と場所を固定して作成します。";
     }
+    if (timeSetting === "manual" && placeSetting === "candidates") {
+      return "日程は固定し、場所候補から参加者と場所を決定します。";
+    }
     if (timeSetting === "manual") {
       return "日程は固定し、場所は候補から決定します。";
     }
     if (timeSetting === "candidates" && placeSetting === "manual") {
       return "日程候補を設定し、場所は固定して作成します。";
     }
+    if (timeSetting === "candidates" && placeSetting === "candidates") {
+      return "日程候補・場所候補から参加者と確定します。";
+    }
     if (timeSetting === "candidates") {
       return "日程候補から参加者と日程を決定します。";
     }
     if (placeSetting === "manual") {
       return "場所は固定し、日程は候補から決定します。";
+    }
+    if (placeSetting === "candidates") {
+      return "場所候補を設定し、日程は候補から決定します。";
     }
     return "日程と場所は候補から決定されます。";
   }, [placeSetting, timeSetting]);
@@ -826,7 +857,7 @@ function EventCreatePageContent() {
             : undefined,
         eventArea: selectedEventArea,
         placeQuery: placeSetting === "auto" && placeQuery.trim() ? placeQuery : undefined,
-        candidatePlaces: placeSetting === "auto" ? candidatePlaces : undefined,
+        candidatePlaces: placeSetting === "candidates" ? candidatePlaces : undefined,
         inviteeIds: selectedInvites,
       };
 
@@ -1507,9 +1538,213 @@ function EventCreatePageContent() {
 
             {(!isFocusMode || capacityTouched) && (
               <section className="rounded-3xl bg-white p-4 shadow-sm">
+                <h2 className="text-sm font-semibold">場所の設定</h2>
+                <p className="mt-1 text-xs text-[var(--muted)]">
+                  場所の決め方を選択してください。
+                </p>
+                <div className="mt-3 space-y-2">
+                  {placeSettingOptions.map((mode) => (
+                    <button
+                      key={`place-${mode.value}`}
+                      onClick={() => setPlaceSetting(mode.value)}
+                      className={`flex w-full items-center justify-between rounded-2xl px-4 py-3 text-left ${
+                        placeSetting === mode.value
+                          ? "bg-orange-50 shadow-md"
+                          : "bg-white shadow-sm"
+                      }`}
+                    >
+                      <div>
+                        <p className="text-sm font-semibold">{mode.label}</p>
+                        <p className="text-xs text-[var(--muted)]">{mode.caption}</p>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        {mode.recommended && (
+                          <span className="rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-semibold text-amber-700">
+                            推奨
+                          </span>
+                        )}
+                        <span className="text-xs font-semibold text-[var(--muted)]">
+                          {placeSetting === mode.value ? "選択中" : "未選択"}
+                        </span>
+                      </div>
+                    </button>
+                  ))}
+                </div>
+
+                {placeSetting === "candidates" && (
+                  <div className="mt-4 space-y-4">
+                    {/* 場所候補リスト */}
+                    <div>
+                      <p className="mb-2 text-xs font-semibold text-[var(--foreground)]">場所候補</p>
+                      {candidatePlaces.length === 0 ? (
+                        <>
+                          <p className="text-xs text-[var(--muted)]">
+                            場所を検索して候補に追加してください。
+                          </p>
+                          <p className="mt-1 text-xs text-rose-500">候補を1件以上追加してください。</p>
+                        </>
+                      ) : (
+                        <div className="space-y-2">
+                          {candidatePlaces.map((place) => (
+                            <div
+                              key={place.placeId}
+                              className="flex items-center gap-3 rounded-2xl bg-orange-50 px-4 py-3 shadow-sm"
+                            >
+                              <div className="min-w-0 flex-1">
+                                <p className="truncate text-sm font-semibold">{place.name}</p>
+                                <p className="mt-1 truncate text-xs text-[var(--muted)]">{place.address}</p>
+                              </div>
+                              <button
+                                onClick={() => toggleCandidatePlace(place)}
+                                className="grid h-6 w-6 flex-shrink-0 place-items-center rounded-full bg-white text-[var(--muted)] shadow-sm"
+                                aria-label="削除"
+                              >
+                                <span className="material-symbols-rounded text-sm">close</span>
+                              </button>
+                            </div>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+
+                    {/* 場所検索 */}
+                    <div className="flex flex-col gap-2 sm:flex-row">
+                      <input
+                        value={placeQuery}
+                        onChange={(event) => setPlaceQuery(event.target.value)}
+                        placeholder="例: 恵比寿 イタリアン"
+                        className="flex-1 rounded-full bg-white px-4 py-2 text-sm shadow-sm"
+                      />
+                      <button
+                        onClick={handleSearchPlaces}
+                        className="flex w-full items-center justify-center gap-2 rounded-full bg-[var(--accent)] px-4 py-2 text-xs font-semibold text-white sm:w-auto"
+                      >
+                        <span className="material-symbols-rounded">search</span>
+                        検索
+                      </button>
+                    </div>
+                    {searchMessage && <p className="text-xs text-[var(--muted)]">{searchMessage}</p>}
+                    {isSearching && <p className="text-xs text-[var(--muted)]">検索中...</p>}
+
+                    {!isSearching && placeResults.length > 0 && (
+                      <div className="max-h-72 space-y-2 overflow-y-auto pr-1">
+                        {placeResults.map((place) => {
+                          const selected = candidatePlaces.some((item) => item.placeId === place.placeId);
+                          const isFull = candidatePlaces.length >= 5;
+                          return (
+                            <div
+                              key={place.placeId}
+                              className={`rounded-2xl px-4 py-3 ${
+                                selected ? "bg-orange-50 shadow-md" : "bg-white shadow-sm"
+                              }`}
+                            >
+                              <div className="flex items-center gap-3">
+                                <Image
+                                  src={place.photoUrl ?? "/file.svg"}
+                                  alt={`${place.name} の写真`}
+                                  width={48}
+                                  height={48}
+                                  className="h-12 w-12 rounded-xl object-cover"
+                                />
+                                <div className="min-w-0 flex-1">
+                                  <p className="truncate text-sm font-semibold">{place.name}</p>
+                                  <p className="mt-1 truncate text-xs text-[var(--muted)]">{place.address}</p>
+                                </div>
+                              </div>
+                              <button
+                                onClick={() => toggleCandidatePlace(place)}
+                                disabled={!selected && isFull}
+                                className={`mt-2 w-full rounded-full px-4 py-2 text-xs font-semibold ${
+                                  selected
+                                    ? "bg-orange-100 text-[var(--accent)]"
+                                    : isFull
+                                      ? "cursor-not-allowed bg-gray-100 text-gray-400 opacity-50"
+                                      : "bg-orange-100 text-[var(--accent)]"
+                                }`}
+                              >
+                                {selected ? "選択中" : isFull ? "上限に達しました" : "候補に追加"}
+                              </button>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    )}
+                  </div>
+                )}
+
+                {placeSetting === "manual" && (
+                  <div className="mt-4 space-y-3">
+                    <div className="flex flex-col gap-2 sm:flex-row">
+                      <input
+                        value={placeQuery}
+                        onChange={(event) => setPlaceQuery(event.target.value)}
+                        placeholder="例: 恵比寿 イタリアン"
+                        className="flex-1 rounded-full bg-white px-4 py-2 text-sm shadow-sm"
+                      />
+                      <button
+                        onClick={handleSearchPlaces}
+                        className="flex w-full items-center justify-center gap-2 rounded-full bg-[var(--accent)] px-4 py-2 text-xs font-semibold text-white sm:w-auto"
+                      >
+                        <span className="material-symbols-rounded">search</span>
+                        検索
+                      </button>
+                    </div>
+                    {searchMessage && <p className="text-xs text-[var(--muted)]">{searchMessage}</p>}
+                    {isSearching && <p className="text-xs text-[var(--muted)]">検索中...</p>}
+
+                    {!isSearching && placeResults.length > 0 && (
+                      <div className="max-h-72 space-y-2 overflow-y-auto pr-1">
+                        {placeResults.map((place) => {
+                          const selected = selectedPlace?.placeId === place.placeId;
+                          return (
+                            <div
+                              key={place.placeId}
+                              className={`rounded-2xl px-4 py-3 ${
+                                selected ? "bg-orange-50 shadow-md" : "bg-white shadow-sm"
+                              }`}
+                            >
+                              <div className="flex items-center gap-3">
+                                <Image
+                                  src={place.photoUrl ?? "/file.svg"}
+                                  alt={`${place.name} の写真`}
+                                  width={48}
+                                  height={48}
+                                  className="h-12 w-12 rounded-xl object-cover"
+                                />
+                                <div className="min-w-0 flex-1">
+                                  <p className="truncate text-sm font-semibold">{place.name}</p>
+                                  <p className="mt-1 truncate text-xs text-[var(--muted)]">{place.address}</p>
+                                </div>
+                              </div>
+                              <button
+                                onClick={() => setSelectedPlace(place)}
+                                className="mt-2 w-full rounded-full bg-orange-100 px-4 py-2 text-xs font-semibold text-[var(--accent)]"
+                              >
+                                {selected ? "選択中" : "この場所で固定"}
+                              </button>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    )}
+
+                    {selectedPlace && (
+                      <div className="rounded-2xl bg-orange-50 p-3 shadow-sm">
+                        <p className="text-xs text-[var(--muted)]">固定する場所</p>
+                        <p className="text-sm font-semibold">{selectedPlace.name}</p>
+                        <p className="text-xs text-[var(--muted)]">{selectedPlace.address}</p>
+                      </div>
+                    )}
+                  </div>
+                )}
+              </section>
+            )}
+
+            {(!isFocusMode || capacityTouched) && (
+              <section className="rounded-3xl bg-white p-4 shadow-sm">
                 <h2 className="text-sm font-semibold">詳細設定（任意）</h2>
                 <p className="mt-1 text-xs text-[var(--muted)]">
-                  場所を手動設定したい場合のみ選択してください。
+                  コメントなど補足情報を入力してください。
                 </p>
 
                 <label className="mt-4 block text-sm">
@@ -1521,108 +1756,6 @@ function EventCreatePageContent() {
                     className="mt-2 h-24 w-full rounded-2xl bg-white px-4 py-3 text-sm shadow-sm"
                   />
                 </label>
-
-                <div className="mt-5">
-                  <p className="mb-2 text-sm font-medium">場所の設定</p>
-                  <div className="space-y-2">
-                    {placeSettingOptions.map((mode) => (
-                      <button
-                        key={`place-${mode.value}`}
-                        onClick={() => setPlaceSetting(mode.value)}
-                        className={`flex w-full items-center justify-between rounded-2xl px-4 py-3 text-left ${
-                          placeSetting === mode.value
-                            ? "bg-orange-50 shadow-md"
-                            : "bg-white shadow-sm"
-                        }`}
-                      >
-                        <div>
-                          <p className="text-sm font-semibold">{mode.label}</p>
-                          <p className="text-xs text-[var(--muted)]">{mode.caption}</p>
-                        </div>
-                        <div className="flex items-center gap-2">
-                          {mode.recommended && (
-                            <span className="rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-semibold text-amber-700">
-                              推奨
-                            </span>
-                          )}
-                          <span className="text-xs font-semibold text-[var(--muted)]">
-                            {placeSetting === mode.value ? "選択中" : "未選択"}
-                          </span>
-                        </div>
-                      </button>
-                    ))}
-                  </div>
-
-                  <div className="mt-3 flex flex-col gap-2 sm:flex-row">
-                    <input
-                      value={placeQuery}
-                      onChange={(event) => setPlaceQuery(event.target.value)}
-                      placeholder="例: 恵比寿 イタリアン"
-                      className="flex-1 rounded-full bg-white px-4 py-2 text-sm shadow-sm"
-                    />
-                    <button
-                      onClick={handleSearchPlaces}
-                      className="flex w-full items-center justify-center gap-2 rounded-full bg-[var(--accent)] px-4 py-2 text-xs font-semibold text-white sm:w-auto"
-                    >
-                      <span className="material-symbols-rounded">search</span>
-                      検索
-                    </button>
-                  </div>
-
-                  {searchMessage && <p className="mt-2 text-xs text-[var(--muted)]">{searchMessage}</p>}
-                  {isSearching && <p className="mt-2 text-xs text-[var(--muted)]">検索中...</p>}
-
-                  {!isSearching && placeResults.length > 0 && (
-                    <div className="mt-3 max-h-72 space-y-2 overflow-y-auto pr-1">
-                      {placeResults.map((place) => {
-                        const selectedInFixed = selectedPlace?.placeId === place.placeId;
-                        const selectedInCandidate = candidatePlaces.some((item) => item.placeId === place.placeId);
-                        const selected = placeSetting === "manual" ? selectedInFixed : selectedInCandidate;
-
-                        return (
-                          <div
-                            key={place.placeId}
-                            className={`rounded-2xl px-4 py-3 ${
-                              selected ? "bg-orange-50 shadow-md" : "bg-white shadow-sm"
-                            }`}
-                          >
-                            <div className="flex items-center gap-3">
-                              <Image
-                                src={place.photoUrl ?? "/file.svg"}
-                                alt={`${place.name} の写真`}
-                                width={48}
-                                height={48}
-                                className="h-12 w-12 rounded-xl object-cover"
-                              />
-                              <div className="min-w-0 flex-1">
-                                <p className="truncate text-sm font-semibold">{place.name}</p>
-                                <p className="mt-1 truncate text-xs text-[var(--muted)]">{place.address}</p>
-                              </div>
-                            </div>
-                            <button
-                              onClick={() =>
-                                placeSetting === "manual"
-                                  ? setSelectedPlace(place)
-                                  : toggleCandidatePlace(place)
-                              }
-                              className="mt-2 w-full rounded-full bg-orange-100 px-4 py-2 text-xs font-semibold text-[var(--accent)]"
-                            >
-                              {selected ? "選択中" : placeSetting === "manual" ? "この場所で固定" : "候補に追加"}
-                            </button>
-                          </div>
-                        );
-                      })}
-                    </div>
-                  )}
-
-                  {placeSetting === "manual" && selectedPlace && (
-                    <div className="mt-3 rounded-2xl bg-orange-50 p-3 shadow-sm">
-                      <p className="text-xs text-[var(--muted)]">固定する場所</p>
-                      <p className="text-sm font-semibold">{selectedPlace.name}</p>
-                      <p className="text-xs text-[var(--muted)]">{selectedPlace.address}</p>
-                    </div>
-                  )}
-                </div>
               </section>
             )}
           </div>

--- a/app/events/new/page.tsx
+++ b/app/events/new/page.tsx
@@ -269,6 +269,10 @@ function EventCreatePageContent() {
 
   const [timeSetting, setTimeSetting] = useState<"auto" | "candidates" | "manual">("auto");
   const [placeSetting, setPlaceSetting] = useState<"auto" | "candidates" | "manual">("auto");
+  const [placeSuggestionPool, setPlaceSuggestionPool] = useState<PlaceResult[]>([]);
+  const [isPlaceSuggestionsLoading, setIsPlaceSuggestionsLoading] = useState(false);
+  const [isPlaceSuggestionsError, setIsPlaceSuggestionsError] = useState(false);
+  const [placeSuggestionRetryCount, setPlaceSuggestionRetryCount] = useState(0);
   const [fixedStart, setFixedStart] = useState("");
   const [activeCandidates, setActiveCandidates] = useState<TimeCandidate[]>([]);
   const [suggestionPool, setSuggestionPool] = useState<TimeCandidate[]>([]);
@@ -297,6 +301,7 @@ function EventCreatePageContent() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const submitLockRef = useRef(false);
   const hasFetchedSuggestionsRef = useRef(false);
+  const lastFetchedPlaceSuggestionKeyRef = useRef<string | null>(null);
 
   const purposeSectionRef = useRef<HTMLElement | null>(null);
   const visibilitySectionRef = useRef<HTMLElement | null>(null);
@@ -491,6 +496,52 @@ function EventCreatePageContent() {
   }, [timeSetting, userId, suggestionRetryCount]);
 
   useEffect(() => {
+    if (placeSetting !== "candidates" || !userId) return;
+
+    const fetchKey = `${effectivePlacePurpose}|${selectedEventArea}`;
+    if (lastFetchedPlaceSuggestionKeyRef.current === fetchKey) return;
+
+    let active = true;
+    setIsPlaceSuggestionsLoading(true);
+    setIsPlaceSuggestionsError(false);
+
+    const loadPlaceSuggestions = async () => {
+      try {
+        const params = new URLSearchParams({ purpose: effectivePlacePurpose });
+        if (selectedEventArea) params.set("eventArea", selectedEventArea);
+
+        const response = await fetch(
+          `/api/profiles/${encodeURIComponent(userId)}/place-suggestions?${params}`,
+          { cache: "no-store" }
+        );
+        if (!active) return;
+        if (response.ok) {
+          const data = (await response.json()) as {
+            defaults: PlaceResult[];
+            suggestions: PlaceResult[];
+          };
+          lastFetchedPlaceSuggestionKeyRef.current = fetchKey;
+          setCandidatePlaces((prev) => (prev.length === 0 ? data.defaults : prev));
+          setPlaceSuggestionPool(data.suggestions);
+        } else {
+          if (!active) return;
+          setIsPlaceSuggestionsError(true);
+        }
+      } catch {
+        if (!active) return;
+        setIsPlaceSuggestionsError(true);
+      } finally {
+        if (active) setIsPlaceSuggestionsLoading(false);
+      }
+    };
+
+    loadPlaceSuggestions();
+    return () => {
+      active = false;
+    };
+  }, [placeSetting, userId, effectivePlacePurpose, selectedEventArea, placeSuggestionRetryCount]);
+
+  useEffect(() => {
     if (!userId) {
       setFriends([]);
       return;
@@ -519,6 +570,11 @@ function EventCreatePageContent() {
     [customPurposeOptions]
   );
 
+  const effectivePlacePurpose = useMemo(
+    () => (purposeElements.length > 0 ? purposeElements.join(" ") : "飲み"),
+    [purposeElements]
+  );
+
   const autoTitle = useMemo(() => buildAutoTitle(purposeElements), [purposeElements]);
   const previousAutoTitleRef = useRef(autoTitle);
   const resolvedTitle = eventTitleInput.trim();
@@ -539,6 +595,8 @@ function EventCreatePageContent() {
 
   const MAX_TIME_CANDIDATES = 5;
   const isCandidateFull = activeCandidates.length >= MAX_TIME_CANDIDATES;
+  const MAX_PLACE_CANDIDATES = 5;
+  const isPlaceCandidateFull = candidatePlaces.length >= MAX_PLACE_CANDIDATES;
 
   const isTimeManualValid =
     timeSetting === "manual"
@@ -1586,16 +1644,30 @@ function EventCreatePageContent() {
 
                 {placeSetting === "candidates" && (
                   <div className="mt-4 space-y-4">
-                    {/* 場所候補リスト */}
+                    {/* 場所候補 */}
                     <div>
                       <p className="mb-2 text-xs font-semibold text-[var(--foreground)]">場所候補</p>
-                      {candidatePlaces.length === 0 ? (
-                        <>
-                          <p className="text-xs text-[var(--muted)]">
-                            場所を検索して候補に追加してください。
+                      {isPlaceSuggestionsLoading ? (
+                        <p className="text-xs text-[var(--muted)]">候補を取得中...</p>
+                      ) : isPlaceSuggestionsError ? (
+                        <div className="space-y-2">
+                          <p className="text-xs text-rose-500">
+                            場所候補の取得に失敗しました。下の検索から手動で追加してください。
                           </p>
-                          <p className="mt-1 text-xs text-rose-500">候補を1件以上追加してください。</p>
-                        </>
+                          <button
+                            onClick={() => {
+                              setIsPlaceSuggestionsError(false);
+                              setPlaceSuggestionRetryCount((c) => c + 1);
+                            }}
+                            className="text-xs text-[var(--accent)] underline"
+                          >
+                            再試行する
+                          </button>
+                        </div>
+                      ) : candidatePlaces.length === 0 ? (
+                        <p className="text-xs text-[var(--muted)]">
+                          候補がありません。下の「提案候補」から選択するか、場所を検索してください。
+                        </p>
                       ) : (
                         <div className="space-y-2">
                           {candidatePlaces.map((place) => (
@@ -1618,9 +1690,50 @@ function EventCreatePageContent() {
                           ))}
                         </div>
                       )}
+                      {candidatePlaces.length === 0 && !isPlaceSuggestionsLoading && (
+                        <p className="mt-1 text-xs text-rose-500">候補を1件以上追加してください。</p>
+                      )}
                     </div>
 
-                    {/* 場所検索 */}
+                    {/* 提案候補 */}
+                    {!isPlaceSuggestionsLoading && placeSuggestionPool.length > 0 && (
+                      <div>
+                        <p className="mb-2 text-xs font-semibold text-[var(--foreground)]">提案候補</p>
+                        {isPlaceCandidateFull && (
+                          <p className="mb-2 text-xs text-[var(--muted)]">
+                            場所候補が{MAX_PLACE_CANDIDATES}件に達したため追加できません。
+                          </p>
+                        )}
+                        <div className="space-y-2">
+                          {placeSuggestionPool.map((place) => (
+                            <button
+                              key={place.placeId}
+                              disabled={isPlaceCandidateFull}
+                              onClick={() => {
+                                if (isPlaceCandidateFull) return;
+                                setPlaceSuggestionPool((prev) =>
+                                  prev.filter((p) => p.placeId !== place.placeId)
+                                );
+                                setCandidatePlaces((prev) => [...prev, place]);
+                              }}
+                              className={`flex w-full items-center justify-between rounded-2xl px-4 py-3 text-left shadow-sm ${
+                                isPlaceCandidateFull
+                                  ? "cursor-not-allowed bg-gray-50 opacity-50"
+                                  : "bg-white"
+                              }`}
+                            >
+                              <div className="min-w-0 flex-1">
+                                <p className="truncate text-sm font-semibold">{place.name}</p>
+                                <p className="mt-1 truncate text-xs text-[var(--muted)]">{place.address}</p>
+                              </div>
+                              <span className="material-symbols-rounded ml-2 flex-shrink-0 text-sm text-[var(--muted)]">add</span>
+                            </button>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+
+                    {/* 場所検索（手動追加） */}
                     <div className="flex flex-col gap-2 sm:flex-row">
                       <input
                         value={placeQuery}
@@ -1643,7 +1756,6 @@ function EventCreatePageContent() {
                       <div className="max-h-72 space-y-2 overflow-y-auto pr-1">
                         {placeResults.map((place) => {
                           const selected = candidatePlaces.some((item) => item.placeId === place.placeId);
-                          const isFull = candidatePlaces.length >= 5;
                           return (
                             <div
                               key={place.placeId}
@@ -1666,16 +1778,16 @@ function EventCreatePageContent() {
                               </div>
                               <button
                                 onClick={() => toggleCandidatePlace(place)}
-                                disabled={!selected && isFull}
+                                disabled={!selected && isPlaceCandidateFull}
                                 className={`mt-2 w-full rounded-full px-4 py-2 text-xs font-semibold ${
                                   selected
                                     ? "bg-orange-100 text-[var(--accent)]"
-                                    : isFull
+                                    : isPlaceCandidateFull
                                       ? "cursor-not-allowed bg-gray-100 text-gray-400 opacity-50"
                                       : "bg-orange-100 text-[var(--accent)]"
                                 }`}
                               >
-                                {selected ? "選択中" : isFull ? "上限に達しました" : "候補に追加"}
+                                {selected ? "選択中" : isPlaceCandidateFull ? "上限に達しました" : "候補に追加"}
                               </button>
                             </div>
                           );


### PR DESCRIPTION
## 概要

PR #68（issue #67）で「日程の設定」を3モード化・詳細設定から独立させたのと同様のパターンを、「場所の設定」に適用する。

**関連ドキュメント**
- Closes #69
- base branch: #68 (`gh-67-extend-date-setting`) — #68 マージ後に base を `develop` にリターゲット予定

## 影響範囲

- DBマイグレーションなし（`EventPlaceCandidate` テーブルは既存のまま使用）
- イベント作成・編集画面のUI変更（場所設定セクションが詳細設定から独立）
- POST/PATCH `/api/events` の `placeSetting` フィールドに `"candidates"` を追加

## 変更点

**AS IS**
- 「場所の設定」は「詳細設定（任意）」accordion 内に2択（おまかせ / 設定する）として存在
- 候補モードの概念なし（`candidatePlaces` は「おまかせ」モードの任意ヒントとして送信）

**TO BE**
- 「場所の設定」を「詳細設定」の上に独立した `<section>` として配置
- 3択に拡張（おまかせ / 場所候補を設定する / 固定）
- 「場所候補を設定する」モード: Google Places 検索→候補リスト管理（上限5件、×削除ボタン付き）
- `EventUpdateComparable` に `candidatePlaceIds` を追加してダーティチェック対応
- 編集時に `placeCandidates` が存在する場合は `"candidates"` モードとして復元
- POST/PATCH API に candidates モードの400バリデーションとトランザクション化したdelete+createを追加

## QA 観点

- 「おまかせ」モードは既存動作と変わらないこと（自動生成、バリデーションなし）
- 「場所候補を設定する」モードで0件のとき「作成する」ボタンが disabled になること
- 「場所候補を設定する」モードで5件上限に達したとき追加ボタンが disabled になること
- 「固定」モードで場所未選択のとき「作成する」ボタンが disabled になること
- モード切替時に `candidatePlaces` 状態が保持されること（切り戻しで復元できる）
- 編集時に既存の場所候補が `"candidates"` モードで正しく復元されること
- 編集時に固定場所があれば `"manual"` モードで復元されること

## 動作確認ケース

- [ ] 新規イベント作成: おまかせ → 保存 → 自動で場所候補が生成される
- [ ] 新規イベント作成: 場所候補を設定する → 検索 → 2件追加 → 保存 → 候補が反映される
- [ ] 新規イベント作成: 固定 → 場所を1件選択 → 保存 → 固定場所が反映される
- [ ] イベント編集: 場所候補あり → candidates モードで復元される
- [ ] イベント編集: 固定場所あり → manual モードで復元される

## レビュアーに特に見て欲しいポイント

- このPRは #68 がマージされ次第、base を `develop` にリターゲットする想定です
- PATCH APIの `shouldReplaceWithUserPlaceCandidates` フラグの条件（`body.candidatePlaces !== undefined && length > 0`）が意図通りかご確認ください