### PR TITLE
[FEAT] イベント管理画面の日程選択・投票表示を改善する

### DIFF
--- a/app/api/events/[id]/route.ts
+++ b/app/api/events/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
+import { TimeAvailability } from "@prisma/client";
 import { getPlacePhotoUrlByPlaceId, getPlacesForQuery } from "@/lib/places";
 import { createAppNotifications } from "@/lib/notification-delivery";
 import { parseIsoDateTimeWithTimeZone } from "@/lib/datetime";
@@ -146,9 +147,21 @@ export async function GET(
       },
     }));
 
+  const availabilityWeight: Record<TimeAvailability, number> = {
+    [TimeAvailability.available]: 2,
+    [TimeAvailability.maybe]: 1,
+    [TimeAvailability.unavailable]: 0,
+  };
+
   const timeCandidates = event.timeCandidates
     .map((candidate: any) => {
-      const availableVotes = candidate.votes.filter((vote: any) => vote.isAvailable).length;
+      const weightedScore = candidate.votes.reduce(
+        (acc: number, vote: any) => acc + (availabilityWeight[vote.availability as TimeAvailability] ?? 0),
+        0
+      );
+      const availableVotes = candidate.votes.filter(
+        (vote: any) => vote.availability === "available"
+      ).length;
       const myVote = viewerId
         ? candidate.votes.find((vote: any) => vote.userId === viewerId)
         : undefined;
@@ -156,15 +169,15 @@ export async function GET(
         id: candidate.id,
         startTime: candidate.startTime,
         endTime: candidate.endTime,
-        score: candidate.score + availableVotes,
+        score: candidate.score + weightedScore,
         source: candidate.source,
         proposedBy: candidate.proposedBy,
         availableVotes,
-        myAvailability: myVote?.isAvailable ?? null,
+        myAvailability: myVote?.availability ?? null,
         votes: candidate.votes.map((vote: any) => ({
           userId: vote.userId,
           displayName: vote.user.displayName,
-          isAvailable: vote.isAvailable,
+          availability: vote.availability,
         })),
       };
     })

--- a/app/api/events/[id]/route.ts
+++ b/app/api/events/[id]/route.ts
@@ -86,7 +86,7 @@ export async function GET(
         include: { inviter: true, invitee: true },
         orderBy: { createdAt: "desc" },
       },
-      timeCandidates: { include: { votes: true } },
+      timeCandidates: { include: { votes: { include: { user: true } } } },
       placeCandidates: { include: { votes: true } },
     },
   });
@@ -161,6 +161,11 @@ export async function GET(
         proposedBy: candidate.proposedBy,
         availableVotes,
         myAvailability: myVote?.isAvailable ?? null,
+        votes: candidate.votes.map((vote: any) => ({
+          userId: vote.userId,
+          displayName: vote.user.displayName,
+          isAvailable: vote.isAvailable,
+        })),
       };
     })
     .sort((a: any, b: any) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime())

--- a/app/api/events/[id]/votes/time/route.ts
+++ b/app/api/events/[id]/votes/time/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
+import { TimeAvailability } from "@prisma/client";
 
 export async function POST(
   request: Request,
@@ -9,12 +10,28 @@ export async function POST(
   const body = (await request.json()) as {
     userId?: string;
     candidateId?: string;
+    availability?: TimeAvailability;
+    // legacy payloads may send `isAvailable: boolean`
     isAvailable?: boolean;
   };
 
   if (!body.userId || !body.candidateId) {
     return NextResponse.json(
       { message: "userId and candidateId are required" },
+      { status: 400 }
+    );
+  }
+
+  const availability =
+    body.availability ??
+    (body.isAvailable !== undefined
+      ? body.isAvailable
+        ? TimeAvailability.available
+        : TimeAvailability.unavailable
+      : TimeAvailability.available);
+  if (!Object.values(TimeAvailability).includes(availability)) {
+    return NextResponse.json(
+      { message: "availability must be available, maybe, or unavailable" },
       { status: 400 }
     );
   }
@@ -53,13 +70,11 @@ export async function POST(
         userId: body.userId,
       },
     },
-    update: {
-      isAvailable: body.isAvailable ?? true,
-    },
+    update: { availability },
     create: {
       candidateId: body.candidateId,
       userId: body.userId,
-      isAvailable: body.isAvailable ?? true,
+      availability,
     },
   });
 

--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -198,7 +198,11 @@ export async function GET(request: Request) {
           )
         : undefined;
       const timeCandidates = [...event.timeCandidates]
-        .sort((a: any, b: any) => b.score - a.score)
+        .sort((a: any, b: any) => {
+          const ta = new Date(a.startTime).getTime();
+          const tb = new Date(b.startTime).getTime();
+          return ta - tb;
+        })
         .slice(0, 3)
         .map((candidate: any) => ({
           id: candidate.id,

--- a/app/events/[id]/manage/page.tsx
+++ b/app/events/[id]/manage/page.tsx
@@ -43,7 +43,7 @@ type EventDetail = {
     startTime: string;
     endTime: string;
     score: number;
-    votes: { userId: string; displayName: string; isAvailable: boolean }[];
+    votes: { userId: string; displayName: string; availability: "available" | "maybe" | "unavailable" }[];
   }[];
   placeCandidates: { id: string; placeId: string; name: string; address: string; score: number }[];
 };
@@ -341,8 +341,9 @@ export default function EventManagePage() {
             ) : (
               <ul className="mt-4 space-y-3">
                 {event.timeCandidates.map((candidate) => {
-                  const availableCount = candidate.votes.filter((v) => v.isAvailable).length;
-                  const notAvailableCount = candidate.votes.filter((v) => !v.isAvailable).length;
+                  const availableCount = candidate.votes.filter((v) => v.availability === "available").length;
+                  const maybeCount = candidate.votes.filter((v) => v.availability === "maybe").length;
+                  const notAvailableCount = candidate.votes.filter((v) => v.availability === "unavailable").length;
                   const approvedParticipants = event.participants.filter((p) => p.status === "approved");
                   const votedUserIds = new Set(candidate.votes.map((v) => v.userId));
                   const notVotedCount = approvedParticipants.filter((p) => !votedUserIds.has(p.userId)).length;
@@ -362,6 +363,9 @@ export default function EventManagePage() {
                         <div className="flex shrink-0 items-center gap-1">
                           <span className="rounded-full bg-emerald-100 px-1.5 py-0.5 text-[10px] font-semibold text-emerald-700">
                             ○{availableCount}
+                          </span>
+                          <span className="rounded-full bg-amber-100 px-1.5 py-0.5 text-[10px] font-semibold text-amber-700">
+                            △{maybeCount}
                           </span>
                           <span className="rounded-full bg-rose-100 px-1.5 py-0.5 text-[10px] font-semibold text-rose-700">
                             ×{notAvailableCount}
@@ -473,8 +477,9 @@ export default function EventManagePage() {
       </main>
 
       {selectedTimeCandidate && (() => {
-        const available = selectedTimeCandidate.votes.filter((v) => v.isAvailable);
-        const notAvailable = selectedTimeCandidate.votes.filter((v) => !v.isAvailable);
+        const available = selectedTimeCandidate.votes.filter((v) => v.availability === "available");
+        const maybe = selectedTimeCandidate.votes.filter((v) => v.availability === "maybe");
+        const notAvailable = selectedTimeCandidate.votes.filter((v) => v.availability === "unavailable");
         const votedUserIds = new Set(selectedTimeCandidate.votes.map((v) => v.userId));
         const approvedParticipants = event.participants.filter((p) => p.status === "approved");
         const notVoted = approvedParticipants.filter((p) => !votedUserIds.has(p.userId));
@@ -507,6 +512,26 @@ export default function EventManagePage() {
                         <li
                           key={v.userId}
                           className="rounded-xl bg-emerald-50 px-3 py-2 text-sm text-[var(--foreground)]"
+                        >
+                          {v.displayName}
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+
+                <div>
+                  <p className="mb-2 text-xs font-semibold text-amber-700">
+                    △ たぶん参加可能（{maybe.length}人）
+                  </p>
+                  {maybe.length === 0 ? (
+                    <p className="text-xs text-[var(--muted)]">なし</p>
+                  ) : (
+                    <ul className="space-y-1">
+                      {maybe.map((v) => (
+                        <li
+                          key={v.userId}
+                          className="rounded-xl bg-amber-50 px-3 py-2 text-sm text-[var(--foreground)]"
                         >
                           {v.displayName}
                         </li>

--- a/app/events/[id]/manage/page.tsx
+++ b/app/events/[id]/manage/page.tsx
@@ -49,7 +49,7 @@ type EventDetail = {
 };
 
 const formatStart = (start: string) => {
-  return formatEventStartLabel(start);
+  return formatEventStartLabel(start, true);
 };
 
 export default function EventManagePage() {
@@ -357,6 +357,20 @@ export default function EventManagePage() {
                       }`}
                     >
                       <div className="flex items-center gap-2">
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setTimeCandidateId(candidate.id);
+                          }}
+                          className={`grid h-5 w-5 shrink-0 place-items-center rounded-full border-2 transition-colors ${
+                            isSelected
+                              ? "border-orange-500 bg-orange-500"
+                              : "border-gray-300 bg-white"
+                          }`}
+                          aria-label="選択"
+                        >
+                          {isSelected && <div className="h-2 w-2 rounded-full bg-white" />}
+                        </button>
                         <p className="min-w-0 flex-1 truncate font-semibold text-[var(--foreground)]">
                           {formatStart(candidate.startTime)}
                         </p>
@@ -374,20 +388,6 @@ export default function EventManagePage() {
                             未{notVotedCount}
                           </span>
                         </div>
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            setTimeCandidateId(candidate.id);
-                          }}
-                          className={`grid h-5 w-5 shrink-0 place-items-center rounded-full border-2 transition-colors ${
-                            isSelected
-                              ? "border-orange-500 bg-orange-500"
-                              : "border-gray-300 bg-white"
-                          }`}
-                          aria-label="選択"
-                        >
-                          {isSelected && <div className="h-2 w-2 rounded-full bg-white" />}
-                        </button>
                       </div>
                     </li>
                   );

--- a/app/events/[id]/manage/page.tsx
+++ b/app/events/[id]/manage/page.tsx
@@ -38,7 +38,13 @@ type EventDetail = {
     };
     createdAt: string;
   }[];
-  timeCandidates: { id: string; startTime: string; endTime: string; score: number }[];
+  timeCandidates: {
+    id: string;
+    startTime: string;
+    endTime: string;
+    score: number;
+    votes: { userId: string; displayName: string; isAvailable: boolean }[];
+  }[];
   placeCandidates: { id: string; placeId: string; name: string; address: string; score: number }[];
 };
 
@@ -67,7 +73,11 @@ export default function EventManagePage() {
             new Date(data.fixedStartTime as string).getTime()
         )
       : null;
-    setTimeCandidateId(matchedTimeCandidate?.id ?? data.timeCandidates[0]?.id ?? null);
+    const highestScoreCandidate =
+      data.timeCandidates.length > 0
+        ? data.timeCandidates.reduce((best, c) => (c.score > best.score ? c : best))
+        : null;
+    setTimeCandidateId(matchedTimeCandidate?.id ?? highestScoreCandidate?.id ?? null);
 
     const matchedPlaceCandidate = data.fixedPlaceId
       ? data.placeCandidates.find((candidate) => candidate.placeId === data.fixedPlaceId)
@@ -304,7 +314,22 @@ export default function EventManagePage() {
 
         <section className="mt-8 grid gap-6 pt-6 md:grid-cols-2">
           <div>
-            <h2 className="text-lg font-semibold">日程候補</h2>
+            {(() => {
+              const approvedCount = event.participants.filter((p) => p.status === "approved").length;
+              const votedCount = new Set(
+                event.timeCandidates.flatMap((c) => c.votes.map((v) => v.userId))
+              ).size;
+              return (
+                <div className="flex items-center gap-3">
+                  <h2 className="text-lg font-semibold">日程候補</h2>
+                  {requiresTimeSelection && (
+                    <span className="rounded-full bg-sky-50 px-2.5 py-1 text-[10px] font-semibold text-sky-700">
+                      {approvedCount}人中{votedCount}人が投票済み
+                    </span>
+                  )}
+                </div>
+              );
+            })()}
             {event.fixedStartTime && (
               <div className="mt-3 rounded-2xl bg-orange-50 p-3 text-xs text-[var(--muted)]">
                 現在の確定: {formatStart(event.fixedStartTime)}
@@ -327,6 +352,22 @@ export default function EventManagePage() {
                       {formatStart(candidate.startTime)}
                     </p>
                     <p className="text-xs text-[var(--muted)]">スコア: {candidate.score}</p>
+                    {candidate.votes.length > 0 && (
+                      <div className="mt-2 flex flex-wrap gap-1">
+                        {candidate.votes.map((vote) => (
+                          <span
+                            key={vote.userId}
+                            className={`inline-flex items-center gap-0.5 rounded-full px-2 py-0.5 text-[10px] font-semibold ${
+                              vote.isAvailable
+                                ? "bg-emerald-100 text-emerald-700"
+                                : "bg-rose-100 text-rose-700"
+                            }`}
+                          >
+                            {vote.isAvailable ? "○" : "×"} {vote.displayName}
+                          </span>
+                        ))}
+                      </div>
+                    )}
                     <button
                       onClick={() => setTimeCandidateId(candidate.id)}
                       className="mt-2 w-full rounded-full bg-white px-3 py-2 text-xs shadow-sm"

--- a/app/events/[id]/manage/page.tsx
+++ b/app/events/[id]/manage/page.tsx
@@ -62,6 +62,7 @@ export default function EventManagePage() {
   const [placeCandidateId, setPlaceCandidateId] = useState<string | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [selectedTimeCandidate, setSelectedTimeCandidate] = useState<EventDetail["timeCandidates"][number] | null>(null);
 
   const applyEventState = (data: EventDetail) => {
     setEvent(data);
@@ -339,43 +340,54 @@ export default function EventManagePage() {
               <p className="mt-4 text-sm text-[var(--muted)]">日程候補はありません。</p>
             ) : (
               <ul className="mt-4 space-y-3">
-                {event.timeCandidates.map((candidate) => (
-                  <li
-                    key={candidate.id}
-                    className={`rounded-2xl p-4 text-sm shadow-sm ${
-                      timeCandidateId === candidate.id
-                        ? "bg-orange-50"
-                        : "bg-white"
-                    }`}
-                  >
-                    <p className="font-semibold text-[var(--foreground)]">
-                      {formatStart(candidate.startTime)}
-                    </p>
-                    <p className="text-xs text-[var(--muted)]">スコア: {candidate.score}</p>
-                    {candidate.votes.length > 0 && (
-                      <div className="mt-2 flex flex-wrap gap-1">
-                        {candidate.votes.map((vote) => (
-                          <span
-                            key={vote.userId}
-                            className={`inline-flex items-center gap-0.5 rounded-full px-2 py-0.5 text-[10px] font-semibold ${
-                              vote.isAvailable
-                                ? "bg-emerald-100 text-emerald-700"
-                                : "bg-rose-100 text-rose-700"
-                            }`}
-                          >
-                            {vote.isAvailable ? "○" : "×"} {vote.displayName}
-                          </span>
-                        ))}
-                      </div>
-                    )}
-                    <button
-                      onClick={() => setTimeCandidateId(candidate.id)}
-                      className="mt-2 w-full rounded-full bg-white px-3 py-2 text-xs shadow-sm"
+                {event.timeCandidates.map((candidate) => {
+                  const availableCount = candidate.votes.filter((v) => v.isAvailable).length;
+                  const notAvailableCount = candidate.votes.filter((v) => !v.isAvailable).length;
+                  const approvedParticipants = event.participants.filter((p) => p.status === "approved");
+                  const votedUserIds = new Set(candidate.votes.map((v) => v.userId));
+                  const notVotedCount = approvedParticipants.filter((p) => !votedUserIds.has(p.userId)).length;
+                  const isSelected = timeCandidateId === candidate.id;
+                  return (
+                    <li
+                      key={candidate.id}
+                      onClick={() => setSelectedTimeCandidate(candidate)}
+                      className={`cursor-pointer rounded-2xl p-4 text-sm shadow-sm transition-colors ${
+                        isSelected ? "bg-orange-50" : "bg-white"
+                      }`}
                     >
-                      選択
-                    </button>
-                  </li>
-                ))}
+                      <div className="flex items-center gap-2">
+                        <p className="min-w-0 flex-1 truncate font-semibold text-[var(--foreground)]">
+                          {formatStart(candidate.startTime)}
+                        </p>
+                        <div className="flex shrink-0 items-center gap-1">
+                          <span className="rounded-full bg-emerald-100 px-1.5 py-0.5 text-[10px] font-semibold text-emerald-700">
+                            ○{availableCount}
+                          </span>
+                          <span className="rounded-full bg-rose-100 px-1.5 py-0.5 text-[10px] font-semibold text-rose-700">
+                            ×{notAvailableCount}
+                          </span>
+                          <span className="rounded-full bg-gray-100 px-1.5 py-0.5 text-[10px] font-semibold text-gray-500">
+                            未{notVotedCount}
+                          </span>
+                        </div>
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setTimeCandidateId(candidate.id);
+                          }}
+                          className={`grid h-5 w-5 shrink-0 place-items-center rounded-full border-2 transition-colors ${
+                            isSelected
+                              ? "border-orange-500 bg-orange-500"
+                              : "border-gray-300 bg-white"
+                          }`}
+                          aria-label="選択"
+                        >
+                          {isSelected && <div className="h-2 w-2 rounded-full bg-white" />}
+                        </button>
+                      </div>
+                    </li>
+                  );
+                })}
               </ul>
             )}
           </div>
@@ -459,6 +471,94 @@ export default function EventManagePage() {
           </button>
         </section>
       </main>
+
+      {selectedTimeCandidate && (() => {
+        const available = selectedTimeCandidate.votes.filter((v) => v.isAvailable);
+        const notAvailable = selectedTimeCandidate.votes.filter((v) => !v.isAvailable);
+        const votedUserIds = new Set(selectedTimeCandidate.votes.map((v) => v.userId));
+        const approvedParticipants = event.participants.filter((p) => p.status === "approved");
+        const notVoted = approvedParticipants.filter((p) => !votedUserIds.has(p.userId));
+        return (
+          <div className="fixed inset-0 z-[60] flex items-end bg-black/35 p-3 sm:items-center sm:justify-center sm:p-6">
+            <div className="max-h-[85vh] w-full max-w-md overflow-y-auto rounded-3xl bg-[var(--surface)] p-4 shadow-2xl">
+              <div className="flex items-center justify-between">
+                <h3 className="text-base font-semibold">
+                  {formatStart(selectedTimeCandidate.startTime)}
+                </h3>
+                <button
+                  onClick={() => setSelectedTimeCandidate(null)}
+                  className="grid h-8 w-8 place-items-center rounded-full bg-white text-[var(--muted)]"
+                  aria-label="閉じる"
+                >
+                  <span className="material-symbols-rounded">close</span>
+                </button>
+              </div>
+
+              <div className="mt-4 space-y-4">
+                <div>
+                  <p className="mb-2 text-xs font-semibold text-emerald-700">
+                    ○ 参加可能（{available.length}人）
+                  </p>
+                  {available.length === 0 ? (
+                    <p className="text-xs text-[var(--muted)]">なし</p>
+                  ) : (
+                    <ul className="space-y-1">
+                      {available.map((v) => (
+                        <li
+                          key={v.userId}
+                          className="rounded-xl bg-emerald-50 px-3 py-2 text-sm text-[var(--foreground)]"
+                        >
+                          {v.displayName}
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+
+                <div>
+                  <p className="mb-2 text-xs font-semibold text-rose-700">
+                    × 参加不可（{notAvailable.length}人）
+                  </p>
+                  {notAvailable.length === 0 ? (
+                    <p className="text-xs text-[var(--muted)]">なし</p>
+                  ) : (
+                    <ul className="space-y-1">
+                      {notAvailable.map((v) => (
+                        <li
+                          key={v.userId}
+                          className="rounded-xl bg-rose-50 px-3 py-2 text-sm text-[var(--foreground)]"
+                        >
+                          {v.displayName}
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+
+                <div>
+                  <p className="mb-2 text-xs font-semibold text-gray-500">
+                    未投票（{notVoted.length}人）
+                  </p>
+                  {notVoted.length === 0 ? (
+                    <p className="text-xs text-[var(--muted)]">全員投票済み</p>
+                  ) : (
+                    <ul className="space-y-1">
+                      {notVoted.map((p) => (
+                        <li
+                          key={p.userId}
+                          className="rounded-xl bg-gray-50 px-3 py-2 text-sm text-[var(--foreground)]"
+                        >
+                          {p.displayName}
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
+        );
+      })()}
     </div>
   );
 }

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -60,7 +60,7 @@ type EventDetail = {
     source: "system" | "proposal";
     proposedBy?: string | null;
     availableVotes: number;
-    myAvailability: boolean | null;
+    myAvailability: "available" | "maybe" | "unavailable" | null;
   }[];
   placeCandidates: {
     id: string;
@@ -233,7 +233,7 @@ export default function EventDetailPage() {
   const [showPlaceOverlay, setShowPlaceOverlay] = useState(false);
   const [selectedPlaceDetail, setSelectedPlaceDetail] = useState<EventDetail["placeCandidates"][number] | null>(null);
   const [proposalStart, setProposalStart] = useState("");
-  const [timeVoteSelection, setTimeVoteSelection] = useState<Record<string, boolean | undefined>>({});
+  const [timeVoteSelection, setTimeVoteSelection] = useState<Record<string, "available" | "maybe" | "unavailable" | undefined>>({});
   const [placeVoteSelection, setPlaceVoteSelection] = useState<Record<string, "good" | "bad" | undefined>>({});
   const [calendarRegistrationVersion, setCalendarRegistrationVersion] = useState<string | null>(null);
   const [isCalendarDownloading, setIsCalendarDownloading] = useState(false);
@@ -675,7 +675,7 @@ export default function EventDetailPage() {
     router.push(`/events/${data.id}`);
   };
 
-  const handleTimeVote = async (candidateId: string, isAvailable: boolean) => {
+  const handleTimeVote = async (candidateId: string, availability: "available" | "maybe" | "unavailable") => {
     const currentTs = new Date().getTime();
     if (
       !userId ||
@@ -685,11 +685,11 @@ export default function EventDetailPage() {
     ) {
       return;
     }
-    setTimeVoteSelection((prev) => ({ ...prev, [candidateId]: isAvailable }));
+    setTimeVoteSelection((prev) => ({ ...prev, [candidateId]: availability }));
     await fetch(`/api/events/${eventId}/votes/time`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ userId, candidateId, isAvailable }),
+      body: JSON.stringify({ userId, candidateId, availability }),
     });
     const query = userId ? `?viewerId=${userId}` : "";
     const response = await fetch(`/api/events/${eventId}${query}`, { cache: "no-store" });
@@ -1332,38 +1332,57 @@ export default function EventDetailPage() {
                       {(() => {
                         const selected =
                           timeVoteSelection[candidate.id] ??
-                          (candidate.myAvailability == null ? undefined : candidate.myAvailability);
+                          (candidate.myAvailability ?? undefined);
+                        const disabled = candidateActionsDisabled || !canAccessParticipantActions;
+                        const baseBtn = `grid h-9 w-9 place-items-center rounded-full text-sm font-bold ${disabled ? "cursor-not-allowed opacity-50" : ""}`;
                         return (
-                      <div className="flex shrink-0 items-center gap-2">
-                        <button
-                          onClick={() => handleTimeVote(candidate.id, true)}
-                          disabled={candidateActionsDisabled || !canAccessParticipantActions}
-                          className={`grid h-9 w-9 place-items-center rounded-full ${
-                            selected === true
-                              ? "bg-emerald-100 text-emerald-700"
-                              : selected === false
-                                ? "bg-gray-100 text-gray-400"
-                                : "bg-white text-[var(--muted)] shadow-sm"
-                          } ${candidateActionsDisabled || !canAccessParticipantActions ? "cursor-not-allowed opacity-50" : ""}`}
-                          aria-label="この候補は参加可能"
-                        >
-                          <span className="material-symbols-rounded text-base">check</span>
-                        </button>
-                        <button
-                          onClick={() => handleTimeVote(candidate.id, false)}
-                          disabled={candidateActionsDisabled || !canAccessParticipantActions}
-                          className={`grid h-9 w-9 place-items-center rounded-full ${
-                            selected === false
-                              ? "bg-rose-100 text-rose-700"
-                              : selected === true
-                                ? "bg-gray-100 text-gray-400"
-                                : "bg-white text-[var(--muted)] shadow-sm"
-                          } ${candidateActionsDisabled || !canAccessParticipantActions ? "cursor-not-allowed opacity-50" : ""}`}
-                          aria-label="この候補は参加不可"
-                        >
-                          <span className="material-symbols-rounded text-base">close</span>
-                        </button>
-                      </div>
+                          <div className="flex shrink-0 items-center gap-1.5">
+                            <button
+                              onClick={() => handleTimeVote(candidate.id, "available")}
+                              disabled={disabled}
+                              aria-pressed={selected === "available"}
+                              className={`${baseBtn} ${
+                                selected === "available"
+                                  ? "bg-emerald-100 text-emerald-700"
+                                  : selected != null
+                                    ? "bg-gray-100 text-gray-400"
+                                    : "bg-white text-[var(--muted)] shadow-sm"
+                              }`}
+                              aria-label="参加できる"
+                            >
+                              <span className="material-symbols-rounded">radio_button_unchecked</span>
+                            </button>
+                            <button
+                              onClick={() => handleTimeVote(candidate.id, "maybe")}
+                              disabled={disabled}
+                              aria-pressed={selected === "maybe"}
+                              className={`${baseBtn} ${
+                                selected === "maybe"
+                                  ? "bg-amber-100 text-amber-700"
+                                  : selected != null
+                                    ? "bg-gray-100 text-gray-400"
+                                    : "bg-white text-[var(--muted)] shadow-sm"
+                              }`}
+                              aria-label="たぶん参加できる"
+                            >
+                              <span className="material-symbols-rounded-outline material-symbols-rounded">change_history</span>
+                            </button>
+                            <button
+                              onClick={() => handleTimeVote(candidate.id, "unavailable")}
+                              disabled={disabled}
+                              aria-pressed={selected === "unavailable"}
+                              className={`${baseBtn} ${
+                                selected === "unavailable"
+                                  ? "bg-rose-100 text-rose-700"
+                                  : selected != null
+                                    ? "bg-gray-100 text-gray-400"
+                                    : "bg-white text-[var(--muted)] shadow-sm"
+                              }`}
+                              aria-label="参加できない"
+                            >
+                              <span className="material-symbols-rounded">close</span>
+                            </button>
+                          </div>
                         );
                       })()}
                     </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -80,6 +80,11 @@ a[class*=" border-"] {
   -webkit-font-smoothing: antialiased;
 }
 
+/* outlined variant for Material Symbols (no fill) */
+.material-symbols-rounded-outline {
+  font-variation-settings: "FILL" 0, "wght" 500, "GRAD" 0, "opsz" 24;
+}
+
 /* スクロールバーを隠す */
 .scrollbar-hide {
   -ms-overflow-style: none;

--- a/prisma/migrations/20260519000000_add_time_availability_enum/migration.sql
+++ b/prisma/migrations/20260519000000_add_time_availability_enum/migration.sql
@@ -1,0 +1,20 @@
+-- CreateEnum
+CREATE TYPE "time_availability" AS ENUM ('available', 'maybe', 'unavailable');
+
+-- AlterTable: add new column (nullable first for data migration)
+ALTER TABLE "event_time_votes" ADD COLUMN "availability" "time_availability";
+
+-- MigrateData: is_available=true -> available, is_available=false -> unavailable
+UPDATE "event_time_votes"
+SET "availability" = CASE
+  WHEN "is_available" = true THEN 'available'::"time_availability"
+  ELSE 'unavailable'::"time_availability"
+END;
+
+-- AlterTable: set NOT NULL after migration
+ALTER TABLE "event_time_votes" ALTER COLUMN "availability" SET NOT NULL;
+ALTER TABLE "event_time_votes" ALTER COLUMN "availability" SET DEFAULT 'available'::"time_availability";
+
+-- migration-safety: allow-destructive
+-- AlterTable: drop old column
+ALTER TABLE "event_time_votes" DROP COLUMN "is_available";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -96,6 +96,14 @@ enum CandidateSource {
   @@map("candidate_source")
 }
 
+enum TimeAvailability {
+  available
+  maybe
+  unavailable
+
+  @@map("time_availability")
+}
+
 enum NotificationType {
   event_confirmed
   invite_received
@@ -279,10 +287,10 @@ model EventPlaceCandidate {
 }
 
 model EventTimeVote {
-  candidateId String   @map("candidate_id") @db.Uuid
-  userId      String   @map("user_id") @db.Uuid
-  isAvailable Boolean  @default(true) @map("is_available")
-  createdAt   DateTime @default(now()) @map("created_at")
+  candidateId  String           @map("candidate_id") @db.Uuid
+  userId       String           @map("user_id") @db.Uuid
+  availability TimeAvailability @default(available) @map("availability")
+  createdAt    DateTime         @default(now()) @map("created_at")
 
   candidate   EventTimeCandidate @relation(fields: [candidateId], references: [id], onDelete: Cascade)
   user        Profile            @relation(fields: [userId], references: [userId], onDelete: Cascade)

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -539,14 +539,14 @@ const placeCandidates = [
 ];
 
 const timeVotes = [
-  { candidateId: timeCandidates[0].id, userId: users[0].userId, isAvailable: true },
-  { candidateId: timeCandidates[0].id, userId: users[1].userId, isAvailable: true },
-  { candidateId: timeCandidates[1].id, userId: users[0].userId, isAvailable: true },
-  { candidateId: timeCandidates[1].id, userId: users[2].userId, isAvailable: false },
-  { candidateId: timeCandidates[2].id, userId: users[1].userId, isAvailable: true },
-  { candidateId: timeCandidates[3].id, userId: users[2].userId, isAvailable: true },
-  { candidateId: timeCandidates[4].id, userId: users[0].userId, isAvailable: true },
-  { candidateId: timeCandidates[5].id, userId: users[5].userId, isAvailable: true },
+  { candidateId: timeCandidates[0].id, userId: users[0].userId, availability: "available" as const },
+  { candidateId: timeCandidates[0].id, userId: users[1].userId, availability: "available" as const },
+  { candidateId: timeCandidates[1].id, userId: users[0].userId, availability: "available" as const },
+  { candidateId: timeCandidates[1].id, userId: users[2].userId, availability: "unavailable" as const },
+  { candidateId: timeCandidates[2].id, userId: users[1].userId, availability: "maybe" as const },
+  { candidateId: timeCandidates[3].id, userId: users[2].userId, availability: "available" as const },
+  { candidateId: timeCandidates[4].id, userId: users[0].userId, availability: "maybe" as const },
+  { candidateId: timeCandidates[5].id, userId: users[5].userId, availability: "available" as const },
 ];
 
 const placeVotes = [

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -351,6 +351,16 @@ const events = [
     fixedPlaceName: "皆生海辺カフェ",
     fixedPlaceAddress: "鳥取県米子市皆生温泉4-8-2",
   },
+  {
+    id: "77777777-eeee-eeee-eeee-eeeeeeeeeeee",
+    ownerId: users[0].userId,
+    purpose: "秋の懇親会",
+    area: "渋谷",
+    visibility: "limited" as const,
+    capacity: 8,
+    status: "open" as const,
+    scheduleMode: "candidate" as const,
+  },
 ];
 
 const participants = [
@@ -371,6 +381,15 @@ const participants = [
   { eventId: events[5].id, userId: users[5].userId, status: "approved" as const, role: "guest" as const },
   { eventId: events[6].id, userId: users[1].userId, status: "approved" as const, role: "owner" as const },
   { eventId: events[6].id, userId: users[0].userId, status: "approved" as const, role: "guest" as const },
+  // 秋の懇親会 (events[7]) — ゆうと がオーナー、6人承認済み + あおいは申請中
+  { eventId: events[7].id, userId: users[0].userId, status: "approved" as const, role: "owner" as const },
+  { eventId: events[7].id, userId: users[1].userId, status: "approved" as const, role: "guest" as const },
+  { eventId: events[7].id, userId: users[2].userId, status: "approved" as const, role: "guest" as const },
+  { eventId: events[7].id, userId: users[3].userId, status: "approved" as const, role: "guest" as const },
+  { eventId: events[7].id, userId: users[4].userId, status: "approved" as const, role: "guest" as const },
+  { eventId: events[7].id, userId: users[5].userId, status: "approved" as const, role: "guest" as const },
+  { eventId: events[7].id, userId: users[6].userId, status: "approved" as const, role: "guest" as const },
+  { eventId: events[7].id, userId: users[7].userId, status: "requested" as const, role: "guest" as const },
 ];
 
 const invites = [
@@ -458,6 +477,48 @@ const timeCandidates = [
     score: 3,
     source: "proposal" as const,
     proposedBy: users[0].userId,
+  },
+  // 秋の懇親会 (events[7]) — 9月〜10月の土曜日 5候補
+  {
+    id: "e9111111-1111-1111-1111-111111111111",
+    eventId: events[7].id,
+    startTime: new Date("2026-09-05T09:00:00.000Z"), // 土 18:00 JST
+    endTime: new Date("2026-09-05T12:00:00.000Z"),
+    score: 0,
+    source: "system" as const,
+  },
+  {
+    id: "e9222222-2222-2222-2222-222222222222",
+    eventId: events[7].id,
+    startTime: new Date("2026-09-12T10:00:00.000Z"), // 土 19:00 JST
+    endTime: new Date("2026-09-12T13:00:00.000Z"),
+    score: 0,
+    source: "system" as const,
+  },
+  {
+    id: "e9333333-3333-3333-3333-333333333333",
+    eventId: events[7].id,
+    startTime: new Date("2026-09-19T09:30:00.000Z"), // 土 18:30 JST
+    endTime: new Date("2026-09-19T12:30:00.000Z"),
+    score: 0,
+    source: "system" as const,
+  },
+  {
+    id: "e9444444-4444-4444-4444-444444444444",
+    eventId: events[7].id,
+    startTime: new Date("2026-09-26T10:00:00.000Z"), // 土 19:00 JST
+    endTime: new Date("2026-09-26T13:00:00.000Z"),
+    score: 0,
+    source: "proposal" as const,
+    proposedBy: users[2].userId,
+  },
+  {
+    id: "e9555555-5555-5555-5555-555555555555",
+    eventId: events[7].id,
+    startTime: new Date("2026-10-03T09:00:00.000Z"), // 土 18:00 JST
+    endTime: new Date("2026-10-03T12:00:00.000Z"),
+    score: 0,
+    source: "system" as const,
   },
 ];
 
@@ -547,6 +608,33 @@ const timeVotes = [
   { candidateId: timeCandidates[3].id, userId: users[2].userId, availability: "available" as const },
   { candidateId: timeCandidates[4].id, userId: users[0].userId, availability: "maybe" as const },
   { candidateId: timeCandidates[5].id, userId: users[5].userId, availability: "available" as const },
+  // 秋の懇親会 — 候補1 (9/5): ○4 △1 ×0 未2 → スコア最高
+  { candidateId: timeCandidates[6].id, userId: users[0].userId, availability: "available" as const },
+  { candidateId: timeCandidates[6].id, userId: users[1].userId, availability: "available" as const },
+  { candidateId: timeCandidates[6].id, userId: users[2].userId, availability: "available" as const },
+  { candidateId: timeCandidates[6].id, userId: users[3].userId, availability: "available" as const },
+  { candidateId: timeCandidates[6].id, userId: users[4].userId, availability: "maybe" as const },
+  // 候補2 (9/12): ○3 △2 ×1 未1
+  { candidateId: timeCandidates[7].id, userId: users[0].userId, availability: "available" as const },
+  { candidateId: timeCandidates[7].id, userId: users[1].userId, availability: "available" as const },
+  { candidateId: timeCandidates[7].id, userId: users[2].userId, availability: "maybe" as const },
+  { candidateId: timeCandidates[7].id, userId: users[3].userId, availability: "maybe" as const },
+  { candidateId: timeCandidates[7].id, userId: users[4].userId, availability: "unavailable" as const },
+  { candidateId: timeCandidates[7].id, userId: users[5].userId, availability: "available" as const },
+  // 候補3 (9/19): △1 — 未投票多め
+  { candidateId: timeCandidates[8].id, userId: users[0].userId, availability: "maybe" as const },
+  { candidateId: timeCandidates[8].id, userId: users[1].userId, availability: "unavailable" as const },
+  // 候補4 (9/26): ×4 ○3 — 逆転パターン
+  { candidateId: timeCandidates[9].id, userId: users[0].userId, availability: "unavailable" as const },
+  { candidateId: timeCandidates[9].id, userId: users[1].userId, availability: "unavailable" as const },
+  { candidateId: timeCandidates[9].id, userId: users[2].userId, availability: "unavailable" as const },
+  { candidateId: timeCandidates[9].id, userId: users[3].userId, availability: "unavailable" as const },
+  { candidateId: timeCandidates[9].id, userId: users[4].userId, availability: "available" as const },
+  { candidateId: timeCandidates[9].id, userId: users[5].userId, availability: "available" as const },
+  { candidateId: timeCandidates[9].id, userId: users[6].userId, availability: "available" as const },
+  // 候補5 (10/3): 少数投票
+  { candidateId: timeCandidates[10].id, userId: users[0].userId, availability: "available" as const },
+  { candidateId: timeCandidates[10].id, userId: users[1].userId, availability: "maybe" as const },
 ];
 
 const placeVotes = [


### PR DESCRIPTION
## 概要

イベント管理画面（/events/[id]/manage）において、日程候補のデフォルト選択・投票者の可視化・投票率の表示を改善する。

**関連ドキュメント**
- Closes #71

## 影響範囲

- 本番環境利用者への影響：イベント管理画面のUI変更のみ
- DBマイグレーション：なし
- API変更：`GET /api/events/[id]` のレスポンスに `timeCandidates[].votes`（投票者情報）を追加（既存フィールドに変更なし）

## 変更点

**AS IS**
- 日程候補のデフォルト選択が配列の先頭（最初の候補）固定
- 誰がどの日程に投票したかが管理画面で確認できない
- 投票人数の集計が分からない

**TO BE**
- デフォルト選択がスコア最高の候補に変わる（並び順は変わらない）
- 各日程候補カードに投票者名と投票内容（○/×）がバッジ表示される
- 「日程候補」見出し横に「X人中Y人が投票済み」バッジが表示される

## QA 観点

- スコアが最高の候補がデフォルト選択（橙色ハイライト）になっているか
- 既に確定済みの日程がある場合、確定時刻に対応する候補が選択されているか（スコア最高より優先）
- 投票データがある場合、候補カードに `○ 山田太郎` / `× 鈴木花子` のようなバッジが表示されるか
- 投票がない候補にはバッジが表示されないか
- 見出し横の投票数バッジが正確か（承認済み参加者数 / ユニーク投票者数）
- 日程候補がない場合（`requiresTimeSelection = false`）、バッジが表示されないか

## 動作確認ケース

1. 投票データのあるイベントの管理画面を開く
   - スコア最高の候補がデフォルト選択されること
   - 候補カードに投票者名・○/×が表示されること
   - 見出し横に「X人中Y人が投票済み」が表示されること
2. 投票データがないイベントの管理画面を開く
   - 見出しバッジは「0人が投票済み」と表示されること
   - 候補カードに投票者バッジが表示されないこと
3. 日程が確定済みのイベントの管理画面を開く
   - 「日程候補」セクションが非表示のため投票数バッジも非表示になること

## レビュアーに特に見て欲しいポイント

- `applyEventState` での `highestScoreCandidate` ロジック（同スコアの場合は配列の前の候補が選ばれる）
- APIレスポンスへの `votes` フィールド追加（`timeCandidates` のみ対象、`placeCandidates` は対象外）