### PR TITLE
feat(events): add confirmation overlay modal for event confirmation

### DIFF
--- a/app/events/[id]/manage/page.tsx
+++ b/app/events/[id]/manage/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
 import { supabase } from "@/lib/supabase/client";
 import { AvatarName } from "@/components/ui/avatar-name";
+import { EventConfirmModal } from "@/components/ui/event-confirm-modal";
 import { formatEventStartLabel } from "@/lib/datetime";
 
 type EventDetail = {
@@ -56,6 +57,8 @@ export default function EventManagePage() {
   const [placeCandidateId, setPlaceCandidateId] = useState<string | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [showConfirmModal, setShowConfirmModal] = useState(false);
+  const [isConfirming, setIsConfirming] = useState(false);
 
   const applyEventState = (data: EventDetail) => {
     setEvent(data);
@@ -182,14 +185,20 @@ export default function EventManagePage() {
     refreshEvent();
   };
 
-  const handleConfirm = async () => {
+  const handleExecuteConfirm = async () => {
     if (!ownerId) return;
-    await fetch(`/api/events/${eventId}/confirm`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ ownerId, timeCandidateId, placeCandidateId }),
-    });
-    refreshEvent();
+    setIsConfirming(true);
+    try {
+      await fetch(`/api/events/${eventId}/confirm`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ownerId, timeCandidateId, placeCandidateId }),
+      });
+      await refreshEvent();
+    } finally {
+      setIsConfirming(false);
+      setShowConfirmModal(false);
+    }
   };
 
   const handleDeleteEvent = async () => {
@@ -377,7 +386,7 @@ export default function EventManagePage() {
 
         <div className="mt-8">
           <button
-            onClick={handleConfirm}
+            onClick={() => setShowConfirmModal(true)}
             disabled={
               !ownerId ||
               event.owner.userId !== ownerId ||
@@ -418,6 +427,13 @@ export default function EventManagePage() {
           </button>
         </section>
       </main>
+
+      <EventConfirmModal
+        isOpen={showConfirmModal}
+        onClose={() => setShowConfirmModal(false)}
+        onConfirm={handleExecuteConfirm}
+        isConfirming={isConfirming}
+      />
     </div>
   );
 }

--- a/components/ui/event-confirm-modal.tsx
+++ b/components/ui/event-confirm-modal.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import React from "react";
+
+type EventConfirmModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  isConfirming?: boolean;
+};
+
+export function EventConfirmModal({
+  isOpen,
+  onClose,
+  onConfirm,
+  isConfirming = false,
+}: EventConfirmModalProps) {
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm animate-in fade-in duration-200"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="confirm-modal-title"
+    >
+      <div
+        className="w-full max-w-sm rounded-3xl bg-white p-6 shadow-xl transition-all scale-100"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex flex-col items-center text-center">
+          <div className="grid h-12 w-12 place-items-center rounded-full bg-amber-100 text-amber-600 mb-3">
+            <span className="material-symbols-rounded text-2xl">error_outline</span>
+          </div>
+
+          <h3 id="confirm-modal-title" className="text-lg font-bold text-[var(--foreground)]">
+            イベントの確定確認
+          </h3>
+
+          <div className="mt-4 space-y-3 rounded-2xl bg-amber-50/80 p-4 text-left text-xs text-amber-900 border border-amber-200/60">
+            <div className="flex items-start gap-2">
+              <span className="material-symbols-rounded text-base text-amber-600 shrink-0 mt-0.5">
+                notifications_active
+              </span>
+              <p className="leading-relaxed">
+                イベントを確定すると、全員に確定の通知がいきます。
+              </p>
+            </div>
+            <div className="flex items-start gap-2 border-t border-amber-200/60 pt-2.5">
+              <span className="material-symbols-rounded text-base text-amber-600 shrink-0 mt-0.5">
+                storefront
+              </span>
+              <p className="leading-relaxed">
+                お店開催の場合、予約はできましたか？まだの場合は、予約をしてから確定させてください。
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-6 flex flex-col gap-2">
+          <button
+            onClick={onConfirm}
+            disabled={isConfirming}
+            className="flex w-full items-center justify-center gap-2 rounded-full bg-[var(--accent)] px-4 py-3 text-sm font-semibold text-white shadow-sm hover:opacity-90 active:scale-[0.98] transition disabled:opacity-50"
+          >
+            <span className="material-symbols-rounded text-lg">check_circle</span>
+            {isConfirming ? "確定処理中..." : "確定する"}
+          </button>
+          <button
+            onClick={onClose}
+            disabled={isConfirming}
+            className="flex w-full items-center justify-center gap-2 rounded-full bg-gray-100 px-4 py-3 text-sm font-semibold text-gray-700 hover:bg-gray-200 active:scale-[0.98] transition disabled:opacity-50"
+          >
+            キャンセル
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
AS IS (変更前):
- イベント管理画面で「確定」ボタンを押した際、確認ダイアログが表示されずに即座に確定APIが実行され、通知送信や店舗予約の未確認による操作ミスの懸念があった。

TO BE (変更後):
- イベント確定ボタン押下時に確認モーダル (EventConfirmModal) を表示するUIを実装。
- 全員への確定通知送信および店舗予約の事前確認を促すメッセージを明示。
- ユーザーが「確定する」を選択した場合のみ確定APIを実行し、「キャンセル」を選択した場合は処理を中断して画面を復帰できるように改善。


